### PR TITLE
Run Solid Queue inside Puma, drop worker dyno

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,5 @@
 release: bin/rails release
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
-# SolidQueue runs in-process via the Puma plugin (config/puma.rb: plugin :solid_queue)
+# SolidQueue runs in-process via the Puma plugin when SOLID_QUEUE_IN_PUMA=1.
+# To revert to a separate worker dyno, uncomment below and unset the env var.
+# worker: bundle exec bin/jobs start

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -43,4 +43,6 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 plugin :tmp_restart
 
 # Run the Solid Queue supervisor inside of Puma for single-dyno deployments.
-plugin :solid_queue
+# Set SOLID_QUEUE_IN_PUMA=1 in production to eliminate the worker dyno.
+# In dev, Procfile.dev starts the worker separately via foreman.
+plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]


### PR DESCRIPTION
Move job processing from a separate worker dyno to Puma's built-in solid_queue plugin. This runs the SQ supervisor as a child process of Puma, eliminating the need for a dedicated Heroku worker.