### PR TITLE
Revert Solid Queue puma plugin to fix R14 memory errors

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,3 @@
 release: bin/rails release
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
-# SolidQueue runs in-process via the Puma plugin when SOLID_QUEUE_IN_PUMA=1.
-# To revert to a separate worker dyno, uncomment below and unset the env var.
-# worker: bundle exec bin/jobs start
+worker: bundle exec bin/jobs start

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -41,8 +41,3 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
-
-# Run the Solid Queue supervisor inside of Puma for single-dyno deployments.
-# Set SOLID_QUEUE_IN_PUMA=1 in production to eliminate the worker dyno.
-# In dev, Procfile.dev starts the worker separately via foreman.
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]


### PR DESCRIPTION
## Summary
- Reverts #319 — running Solid Queue inside Puma exceeds the 512MB essential-1 dyno memory quota, causing persistent R14 errors (~every 20s)
- Restores the dedicated `worker` dyno in the Procfile for job processing
- Removes `plugin :solid_queue` from `config/puma.rb`

### Heroku metrics show big problems starting after plugin deployed
<img width="1203" height="492" alt="Screenshot 2026-03-28 at 12 56 44 PM" src="https://github.com/user-attachments/assets/56d5eea3-2fc0-4c8e-9712-3f707e10d0ac" />



## Post-deploy
- [ ] `heroku ps:scale worker=1 --app motzibread`
- [ ] Remove the stale `SOLID_QUEUE_IN_PUMA` env var from Heroku

## Test plan
- [x] Rails tests pass (303 runs, 0 failures)
- [ ] Verify R14 errors stop after deploy
- [ ] Verify Solid Queue jobs process on the worker dyno

🤖 Generated with [Claude Code](https://claude.com/claude-code)