### PR TITLE
Analysis replies via email (reply → In-Reply-To → prompt)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,20 @@ Screenshots are uploaded to `s3://motzi/public/gh/pr-<NUMBER>/` and embedded in 
 
 Heroku app `motzibread` auto-deploys from `master` when CI passes. Heroku Postgres 15 (essential-1), **not** Neon. No Redis — everything runs on Postgres via Solid Queue (jobs), Solid Cable (ActionCable), and Solid Cache. To pull prod data locally: `bin/seed_local` (uses `heroku pg:pull`).
 
+## Analysis Replies (email ingress)
+
+The weekly anomaly report emails have a `Reply-To` of `reply+analysis-{id}@thepuff.co`. A Cloudflare Email Worker (`cloudflare/workers/reply-ingress/`) receives replies and POSTs them to `/reply_ingress` on Motzi, where they get stored as `AnalysisReply` records and fed into next week's prompt.
+
+**Required env var on Heroku:** `REPLY_WEBHOOK_SECRET` (shared with the worker)
+
+Generate a new one: `ruby -rsecurerandom -e 'puts SecureRandom.hex(32)'`
+
+Set on Heroku: `heroku config:set REPLY_WEBHOOK_SECRET=... --app motzibread`
+
+Set on worker: `cd cloudflare/workers/reply-ingress && wrangler secret put REPLY_WEBHOOK_SECRET` (paste same value)
+
+Worker deploy: `cd cloudflare/workers/reply-ingress && wrangler deploy`
+
 ## Dev Shortcuts
 
 - **Admin login** (dev only): `GET /dev/login_as_admin` — signs in as admin, no password. Useful for Playwright.

--- a/app/admin/activity_feed.rb
+++ b/app/admin/activity_feed.rb
@@ -35,7 +35,7 @@ ActiveAdmin.register_page "Activity Feed" do
     feed = ActivityFeed.new(week_id)
     events = feed.summary
     email_summary = feed.email_summary
-    analyses = AnomalyAnalysis.for_week(week_id).order(created_at: :desc)
+    analyses = AnomalyAnalysis.for_week(week_id).includes(:replies).order(created_at: :desc)
     headline_metrics = feed.headline_metrics
     commits = feed.git_commits
     comparison = feed.comparison_snapshot

--- a/app/admin/activity_feed.rb
+++ b/app/admin/activity_feed.rb
@@ -546,6 +546,23 @@ ActiveAdmin.register_page "Activity Feed" do
               text_node markdown.render(analysis.result).html_safe
             end
 
+            if analysis.replies.any?
+              div class: "analysis-replies", style: "margin-top: 16px; padding-top: 12px; border-top: 1px solid #eee" do
+                h4 "Replies (#{analysis.replies.size})", style: "margin: 0 0 8px; font-size: 13px; color: #666"
+                analysis.replies.each do |reply|
+                  div class: "analysis-reply", style: "margin-bottom: 10px; padding: 8px 12px; background: #f9f9fb; border-left: 3px solid #352C63; font-size: 13px" do
+                    div style: "font-weight: 500; color: #352C63; margin-bottom: 4px" do
+                      who = reply.author_name.presence || reply.author_email
+                      text_node "#{who} · #{reply.created_at.strftime('%-m/%-d %l:%M%P').strip} · via #{reply.source}"
+                    end
+                    div style: "white-space: pre-wrap; color: #2E2927" do
+                      text_node reply.body
+                    end
+                  end
+                end
+              end
+            end
+
             div class: "analysis-footer" do
               cost = analysis.cost || AnomalyDetector.estimate_cost(analysis.input_tokens, analysis.output_tokens, analysis.model_used)
               span do

--- a/app/controllers/reply_ingress_controller.rb
+++ b/app/controllers/reply_ingress_controller.rb
@@ -2,7 +2,7 @@ class ReplyIngressController < ActionController::API
   before_action :authenticate!
 
   def create
-    analysis = AnomalyAnalysis.find_by(id: params[:analysis_id])
+    analysis = find_analysis
     return render json: { error: "Unknown analysis" }, status: :not_found unless analysis
 
     author_email = params[:from_email].to_s.downcase
@@ -34,6 +34,14 @@ class ReplyIngressController < ActionController::API
     return if expected.present? && ActiveSupport::SecurityUtils.secure_compare(token, expected)
 
     render json: { error: "Unauthorized" }, status: :unauthorized
+  end
+
+  def find_analysis
+    if params[:in_reply_to].present?
+      AnomalyAnalysis.find_by(email_message_id: params[:in_reply_to])
+    elsif params[:analysis_id].present?
+      AnomalyAnalysis.find_by(id: params[:analysis_id])
+    end
   end
 
   def strip_quoted(body)

--- a/app/controllers/reply_ingress_controller.rb
+++ b/app/controllers/reply_ingress_controller.rb
@@ -2,11 +2,11 @@ class ReplyIngressController < ActionController::API
   before_action :authenticate!
 
   def create
-    analysis = find_analysis
+    analysis = AnomalyAnalysis.find_by(id: params[:in_reply_to].to_s[/analysis-(\d+)@/, 1])
     return render json: { error: "Unknown analysis" }, status: :not_found unless analysis
 
     author_email = params[:from_email].to_s.downcase
-    user = User.find_by("LOWER(email) = ?", author_email)
+    user = User.find_by(email: author_email)
 
     unless user&.is_admin?
       return render json: { error: "Sender not authorized" }, status: :forbidden
@@ -34,14 +34,6 @@ class ReplyIngressController < ActionController::API
     return if expected.present? && ActiveSupport::SecurityUtils.secure_compare(token, expected)
 
     render json: { error: "Unauthorized" }, status: :unauthorized
-  end
-
-  def find_analysis
-    if params[:in_reply_to].present?
-      AnomalyAnalysis.find_by(email_message_id: params[:in_reply_to])
-    elsif params[:analysis_id].present?
-      AnomalyAnalysis.find_by(id: params[:analysis_id])
-    end
   end
 
   def strip_quoted(body)

--- a/app/controllers/reply_ingress_controller.rb
+++ b/app/controllers/reply_ingress_controller.rb
@@ -24,6 +24,8 @@ class ReplyIngressController < ActionController::API
     render json: { id: reply.id }, status: :created
   rescue ActiveRecord::RecordNotUnique
     render json: { status: "duplicate" }, status: :ok
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
   end
 
   private
@@ -31,12 +33,14 @@ class ReplyIngressController < ActionController::API
   def authenticate!
     expected = ENV["REPLY_WEBHOOK_SECRET"].to_s
     token = request.headers["Authorization"].to_s.sub(/^Bearer /, "")
-    return if expected.present? && ActiveSupport::SecurityUtils.secure_compare(token, expected)
+    return if expected.present? &&
+              token.bytesize == expected.bytesize &&
+              ActiveSupport::SecurityUtils.secure_compare(token, expected)
 
     render json: { error: "Unauthorized" }, status: :unauthorized
   end
 
   def strip_quoted(body)
-    body.to_s.split(/\n(On .+ wrote:|>.*|-+Original Message-+)/m).first.to_s.strip
+    body.to_s.split(/^(On .+ wrote:|>.*|-+Original Message-+)/).first.to_s.strip
   end
 end

--- a/app/controllers/reply_ingress_controller.rb
+++ b/app/controllers/reply_ingress_controller.rb
@@ -1,0 +1,42 @@
+class ReplyIngressController < ActionController::API
+  before_action :authenticate!
+
+  def create
+    analysis = AnomalyAnalysis.find_by(id: params[:analysis_id])
+    return render json: { error: "Unknown analysis" }, status: :not_found unless analysis
+
+    author_email = params[:from_email].to_s.downcase
+    user = User.find_by("LOWER(email) = ?", author_email)
+
+    unless user&.is_admin?
+      return render json: { error: "Sender not authorized" }, status: :forbidden
+    end
+
+    reply = analysis.replies.create!(
+      user: user,
+      author_email: author_email,
+      author_name: params[:from_name],
+      body: strip_quoted(params[:body]),
+      message_id: params[:message_id],
+      source: :email
+    )
+
+    render json: { id: reply.id }, status: :created
+  rescue ActiveRecord::RecordNotUnique
+    render json: { status: "duplicate" }, status: :ok
+  end
+
+  private
+
+  def authenticate!
+    expected = ENV["REPLY_WEBHOOK_SECRET"].to_s
+    token = request.headers["Authorization"].to_s.sub(/^Bearer /, "")
+    return if expected.present? && ActiveSupport::SecurityUtils.secure_compare(token, expected)
+
+    render json: { error: "Unauthorized" }, status: :unauthorized
+  end
+
+  def strip_quoted(body)
+    body.to_s.split(/\n(On .+ wrote:|>.*|-+Original Message-+)/m).first.to_s.strip
+  end
+end

--- a/app/mailers/anomaly_mailer.rb
+++ b/app/mailers/anomaly_mailer.rb
@@ -1,21 +1,11 @@
 class AnomalyMailer < ApplicationMailer
-  REPLY_ADDRESS = "motzi-analysis-replies@thepuff.co".freeze
-  MESSAGE_ID_DOMAIN = "motzibread.herokuapp.com".freeze
-
   def anomaly_report
     @analysis = params[:analysis]
 
-    # Stable per-analysis Message-ID so replies can be matched via In-Reply-To.
-    # Stored on the analysis the first time the mail is built.
-    if @analysis.email_message_id.blank?
-      @analysis.update_column(:email_message_id,
-        "<analysis-#{@analysis.id}-#{SecureRandom.hex(8)}@#{MESSAGE_ID_DOMAIN}>")
-    end
-
     mail(to: User.kyle.email_list,
-         reply_to: REPLY_ADDRESS,
+         reply_to: "motzi-analysis-replies@thepuff.co",
          subject: "#{@analysis.status_emoji} #{@analysis.overall_status.capitalize} — #{@analysis.week_id} Motzi Activity Report",
-         message_id: @analysis.email_message_id) do |format|
+         message_id: "analysis-#{@analysis.id}@motzibread.herokuapp.com") do |format|
       format.text
       format.mjml
     end

--- a/app/mailers/anomaly_mailer.rb
+++ b/app/mailers/anomaly_mailer.rb
@@ -1,11 +1,21 @@
 class AnomalyMailer < ApplicationMailer
-  REPLY_DOMAIN = "thepuff.co".freeze
+  REPLY_ADDRESS = "motzi-analysis-replies@thepuff.co".freeze
+  MESSAGE_ID_DOMAIN = "motzibread.herokuapp.com".freeze
 
   def anomaly_report
     @analysis = params[:analysis]
+
+    # Stable per-analysis Message-ID so replies can be matched via In-Reply-To.
+    # Stored on the analysis the first time the mail is built.
+    if @analysis.email_message_id.blank?
+      @analysis.update_column(:email_message_id,
+        "<analysis-#{@analysis.id}-#{SecureRandom.hex(8)}@#{MESSAGE_ID_DOMAIN}>")
+    end
+
     mail(to: User.kyle.email_list,
-         reply_to: "reply+analysis-#{@analysis.id}@#{REPLY_DOMAIN}",
-         subject: "#{@analysis.status_emoji} #{@analysis.overall_status.capitalize} — #{@analysis.week_id} Motzi Activity Report") do |format|
+         reply_to: REPLY_ADDRESS,
+         subject: "#{@analysis.status_emoji} #{@analysis.overall_status.capitalize} — #{@analysis.week_id} Motzi Activity Report",
+         message_id: @analysis.email_message_id) do |format|
       format.text
       format.mjml
     end

--- a/app/mailers/anomaly_mailer.rb
+++ b/app/mailers/anomaly_mailer.rb
@@ -1,7 +1,10 @@
 class AnomalyMailer < ApplicationMailer
+  REPLY_DOMAIN = "thepuff.co".freeze
+
   def anomaly_report
     @analysis = params[:analysis]
     mail(to: User.kyle.email_list,
+         reply_to: "reply+analysis-#{@analysis.id}@#{REPLY_DOMAIN}",
          subject: "#{@analysis.status_emoji} #{@analysis.overall_status.capitalize} — #{@analysis.week_id} Motzi Activity Report") do |format|
       format.text
       format.mjml

--- a/app/models/analysis_reply.rb
+++ b/app/models/analysis_reply.rb
@@ -3,7 +3,8 @@ class AnalysisReply < ApplicationRecord
   belongs_to :user, optional: true
 
   validates :body, :author_email, presence: true
-  validates :message_id, uniqueness: true, allow_nil: true
+  # Uniqueness enforced at DB level (unique index); the controller rescues
+  # ActiveRecord::RecordNotUnique for idempotent duplicate handling.
 
   enum :source, { email: 0, admin: 1 }
 end

--- a/app/models/analysis_reply.rb
+++ b/app/models/analysis_reply.rb
@@ -1,0 +1,9 @@
+class AnalysisReply < ApplicationRecord
+  belongs_to :anomaly_analysis
+  belongs_to :user, optional: true
+
+  validates :body, :author_email, presence: true
+  validates :message_id, uniqueness: true, allow_nil: true
+
+  enum :source, { email: 0, admin: 1 }
+end

--- a/app/models/anomaly_analysis.rb
+++ b/app/models/anomaly_analysis.rb
@@ -1,5 +1,6 @@
 class AnomalyAnalysis < ApplicationRecord
   belongs_to :user, optional: true
+  has_many :replies, -> { order(:created_at) }, class_name: "AnalysisReply", dependent: :destroy
 
   validates :week_id, :result, :trigger, presence: true
 

--- a/app/services/anomaly_detector.rb
+++ b/app/services/anomaly_detector.rb
@@ -100,6 +100,15 @@ class AnomalyDetector
         parts << ""
         parts << "### #{a.week_id} — #{a.created_at.strftime('%-m/%-d/%Y')} (#{a.trigger})"
         parts << a.result
+
+        if a.replies.any?
+          parts << ""
+          parts << "**Operator replies:**"
+          a.replies.each do |r|
+            who = r.author_name.presence || r.author_email
+            parts << "- #{who} (#{r.created_at.strftime('%-m/%-d')}): #{r.body}"
+          end
+        end
       end
     end
 
@@ -128,7 +137,7 @@ class AnomalyDetector
   end
 
   def recent_analyses
-    AnomalyAnalysis.order(created_at: :desc).limit(6).to_a.reverse
+    AnomalyAnalysis.includes(:replies).order(created_at: :desc).limit(6).to_a.reverse
   end
 
   def call_claude(user_message)

--- a/cloudflare/workers/CLAUDE.md
+++ b/cloudflare/workers/CLAUDE.md
@@ -1,0 +1,17 @@
+# Cloudflare Workers
+
+Deployed via [Wrangler](https://developers.cloudflare.com/workers/wrangler/). Each subdirectory is a separate worker with its own `wrangler.toml`.
+
+## Deploy
+
+```bash
+cd cloudflare/workers/<worker-name>
+bun install
+wrangler deploy
+```
+
+## Workers
+
+### reply-ingress
+
+Receives email replies at `reply+*@thepuff.co` via Cloudflare Email Routing. Extracts the analysis ID from the To address, verifies SPF/DKIM, parses the email body, and POSTs to the Motzi `/reply_ingress` endpoint with a shared secret. If Motzi rejects (or the email fails verification), the worker bounces the message back to the sender with an explanation.

--- a/cloudflare/workers/CLAUDE.md
+++ b/cloudflare/workers/CLAUDE.md
@@ -14,4 +14,4 @@ wrangler deploy
 
 ### reply-ingress
 
-Receives email replies at `reply+*@thepuff.co` via Cloudflare Email Routing. Extracts the analysis ID from the To address, verifies SPF/DKIM, parses the email body, and POSTs to the Motzi `/reply_ingress` endpoint with a shared secret. If Motzi rejects (or the email fails verification), the worker bounces the message back to the sender with an explanation.
+Receives email replies at `motzi-analysis-replies@thepuff.co` via Cloudflare Email Routing. Verifies SPF/DKIM, parses the MIME body, extracts the `In-Reply-To` header (matched against `AnomalyAnalysis#email_message_id`), and POSTs to the Motzi `/reply_ingress` endpoint with a shared secret. If Motzi rejects (or the email fails verification), the worker bounces the message back to the sender with an explanation.

--- a/cloudflare/workers/reply-ingress/.gitignore
+++ b/cloudflare/workers/reply-ingress/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.wrangler/
+.dev.vars

--- a/cloudflare/workers/reply-ingress/README.md
+++ b/cloudflare/workers/reply-ingress/README.md
@@ -4,11 +4,12 @@ Cloudflare Email Worker that receives replies to the Motzi Activity Report email
 
 ## How it works
 
-1. User replies to the weekly Activity Report email (Reply-To: `reply+analysis-{id}@thepuff.co`).
-2. Cloudflare Email Routing forwards `reply+*@thepuff.co` to this worker.
-3. Worker verifies SPF and DKIM passed, extracts the analysis ID, parses the email body using `postal-mime`, and POSTs JSON to `${MOTZI_URL}/reply_ingress` with a Bearer token.
-4. Motzi validates the sender is an admin and creates an `AnalysisReply`.
-5. If anything fails (SPF, DKIM, unknown analysis, non-admin sender, Motzi error), the worker calls `message.setReject(reason)` and Cloudflare bounces the email back to the sender.
+1. Motzi's `AnomalyMailer` sends each weekly Activity Report with a stable `Message-ID` (persisted on the `AnomalyAnalysis` as `email_message_id`) and `Reply-To: motzi-analysis-replies@thepuff.co`.
+2. User replies — their email client preserves the original Message-ID in `In-Reply-To`.
+3. Cloudflare Email Routing forwards `motzi-analysis-replies@thepuff.co` to this worker.
+4. Worker verifies SPF and DKIM, parses the MIME via `postal-mime`, and POSTs the `In-Reply-To` value plus sender/body to `${MOTZI_URL}/reply_ingress` with a Bearer token.
+5. Motzi looks up the analysis by `email_message_id`, validates the sender is an admin, and creates an `AnalysisReply`.
+6. If anything fails (SPF, DKIM, unknown analysis, non-admin sender, Motzi error), the worker calls `message.setReject(reason)` and Cloudflare bounces the email back to the sender.
 
 ## Deploy
 
@@ -22,7 +23,7 @@ wrangler deploy
 
 Then in Cloudflare dashboard → thepuff.co → Email → Email Routing:
 - Enable Email Routing if not already enabled
-- Add a custom address rule: `reply+*@thepuff.co` → send to worker `motzi-reply-ingress`
+- Add a custom address: `motzi-analysis-replies@thepuff.co` → action "Send to a Worker" → `motzi-reply-ingress`
 
 ## Testing
 

--- a/cloudflare/workers/reply-ingress/README.md
+++ b/cloudflare/workers/reply-ingress/README.md
@@ -1,0 +1,29 @@
+# motzi-reply-ingress
+
+Cloudflare Email Worker that receives replies to the Motzi Activity Report emails and POSTs them to the Motzi Rails app.
+
+## How it works
+
+1. User replies to the weekly Activity Report email (Reply-To: `reply+analysis-{id}@thepuff.co`).
+2. Cloudflare Email Routing forwards `reply+*@thepuff.co` to this worker.
+3. Worker verifies SPF and DKIM passed, extracts the analysis ID, parses the email body using `postal-mime`, and POSTs JSON to `${MOTZI_URL}/reply_ingress` with a Bearer token.
+4. Motzi validates the sender is an admin and creates an `AnalysisReply`.
+5. If anything fails (SPF, DKIM, unknown analysis, non-admin sender, Motzi error), the worker calls `message.setReject(reason)` and Cloudflare bounces the email back to the sender.
+
+## Deploy
+
+```bash
+cd cloudflare/workers/reply-ingress
+bun install
+wrangler login        # once
+wrangler secret put REPLY_WEBHOOK_SECRET   # paste the same value as Heroku's REPLY_WEBHOOK_SECRET
+wrangler deploy
+```
+
+Then in Cloudflare dashboard → thepuff.co → Email → Email Routing:
+- Enable Email Routing if not already enabled
+- Add a custom address rule: `reply+*@thepuff.co` → send to worker `motzi-reply-ingress`
+
+## Testing
+
+Send a real reply to a Motzi Activity Report email. Tail logs with `wrangler tail`.

--- a/cloudflare/workers/reply-ingress/bun.lock
+++ b/cloudflare/workers/reply-ingress/bun.lock
@@ -1,0 +1,232 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "motzi-reply-ingress",
+      "dependencies": {
+        "postal-mime": "^2.2.7",
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20240925.0",
+        "typescript": "^5.5.0",
+        "wrangler": "^3.80.0",
+      },
+    },
+  },
+  "packages": {
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.3.4", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.0.2", "", { "peerDependencies": { "unenv": "2.0.0-rc.14", "workerd": "^1.20250124.0" }, "optionalPeers": ["workerd"] }, "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250718.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20250718.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20250718.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20250718.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250718.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260413.1", "", {}, "sha512-4FFHIVIk645Wf20eCVfe0eM3ERsEw98DFng76QZf1C1JMgIVlfSV2gZF1EyXxNVwOG0RM/CBlu07+u/Z/0Oq9Q=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+
+    "@esbuild-plugins/node-globals-polyfill": ["@esbuild-plugins/node-globals-polyfill@0.2.3", "", { "peerDependencies": { "esbuild": "*" } }, "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw=="],
+
+    "@esbuild-plugins/node-modules-polyfill": ["@esbuild-plugins/node-modules-polyfill@0.2.2", "", { "dependencies": { "escape-string-regexp": "^4.0.0", "rollup-plugin-node-polyfills": "^0.2.1" }, "peerDependencies": { "esbuild": "*" } }, "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.17.19", "", { "os": "android", "cpu": "arm" }, "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.17.19", "", { "os": "android", "cpu": "arm64" }, "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.17.19", "", { "os": "android", "cpu": "x64" }, "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.17.19", "", { "os": "darwin", "cpu": "arm64" }, "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.17.19", "", { "os": "darwin", "cpu": "x64" }, "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.17.19", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.17.19", "", { "os": "freebsd", "cpu": "x64" }, "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.17.19", "", { "os": "linux", "cpu": "arm" }, "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.17.19", "", { "os": "linux", "cpu": "arm64" }, "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.17.19", "", { "os": "linux", "cpu": "ia32" }, "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.17.19", "", { "os": "linux", "cpu": "ppc64" }, "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.17.19", "", { "os": "linux", "cpu": "s390x" }, "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.17.19", "", { "os": "linux", "cpu": "x64" }, "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.17.19", "", { "os": "none", "cpu": "x64" }, "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.17.19", "", { "os": "openbsd", "cpu": "x64" }, "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.17.19", "", { "os": "sunos", "cpu": "x64" }, "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.17.19", "", { "os": "win32", "cpu": "arm64" }, "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.17.19", "", { "os": "win32", "cpu": "ia32" }, "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.17.19", "", { "os": "win32", "cpu": "x64" }, "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA=="],
+
+    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.0.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.0.4" }, "os": "linux", "cpu": "s390x" }, "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
+
+    "acorn-walk": ["acorn-walk@8.3.2", "", {}, "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="],
+
+    "as-table": ["as-table@1.0.55", "", { "dependencies": { "printable-characters": "^1.0.42" } }, "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ=="],
+
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
+    "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@2.0.2", "", {}, "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA=="],
+
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "esbuild": ["esbuild@0.17.19", "", { "optionalDependencies": { "@esbuild/android-arm": "0.17.19", "@esbuild/android-arm64": "0.17.19", "@esbuild/android-x64": "0.17.19", "@esbuild/darwin-arm64": "0.17.19", "@esbuild/darwin-x64": "0.17.19", "@esbuild/freebsd-arm64": "0.17.19", "@esbuild/freebsd-x64": "0.17.19", "@esbuild/linux-arm": "0.17.19", "@esbuild/linux-arm64": "0.17.19", "@esbuild/linux-ia32": "0.17.19", "@esbuild/linux-loong64": "0.17.19", "@esbuild/linux-mips64el": "0.17.19", "@esbuild/linux-ppc64": "0.17.19", "@esbuild/linux-riscv64": "0.17.19", "@esbuild/linux-s390x": "0.17.19", "@esbuild/linux-x64": "0.17.19", "@esbuild/netbsd-x64": "0.17.19", "@esbuild/openbsd-x64": "0.17.19", "@esbuild/sunos-x64": "0.17.19", "@esbuild/win32-arm64": "0.17.19", "@esbuild/win32-ia32": "0.17.19", "@esbuild/win32-x64": "0.17.19" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "estree-walker": ["estree-walker@0.6.1", "", {}, "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="],
+
+    "exit-hook": ["exit-hook@2.2.1", "", {}, "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="],
+
+    "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-source": ["get-source@2.0.12", "", { "dependencies": { "data-uri-to-buffer": "^2.0.0", "source-map": "^0.6.1" } }, "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w=="],
+
+    "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
+
+    "is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
+
+    "magic-string": ["magic-string@0.25.9", "", { "dependencies": { "sourcemap-codec": "^1.4.8" } }, "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ=="],
+
+    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+
+    "miniflare": ["miniflare@3.20250718.3", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "stoppable": "1.1.0", "undici": "^5.28.5", "workerd": "1.20250718.0", "ws": "8.18.0", "youch": "3.3.4", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ=="],
+
+    "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
+
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
+
+    "printable-characters": ["printable-characters@1.0.42", "", {}, "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ=="],
+
+    "rollup-plugin-inject": ["rollup-plugin-inject@3.0.2", "", { "dependencies": { "estree-walker": "^0.6.1", "magic-string": "^0.25.3", "rollup-pluginutils": "^2.8.1" } }, "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w=="],
+
+    "rollup-plugin-node-polyfills": ["rollup-plugin-node-polyfills@0.2.1", "", { "dependencies": { "rollup-plugin-inject": "^3.0.0" } }, "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA=="],
+
+    "rollup-pluginutils": ["rollup-pluginutils@2.8.2", "", { "dependencies": { "estree-walker": "^0.6.1" } }, "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
+
+    "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "sourcemap-codec": ["sourcemap-codec@1.4.8", "", {}, "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="],
+
+    "stacktracey": ["stacktracey@2.2.0", "", { "dependencies": { "as-table": "^1.0.36", "get-source": "^2.0.12" } }, "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg=="],
+
+    "stoppable": ["stoppable@1.1.0", "", {}, "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
+
+    "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
+
+    "unenv": ["unenv@2.0.0-rc.14", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.1", "ohash": "^2.0.10", "pathe": "^2.0.3", "ufo": "^1.5.4" } }, "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q=="],
+
+    "workerd": ["workerd@1.20250718.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250718.0", "@cloudflare/workerd-darwin-arm64": "1.20250718.0", "@cloudflare/workerd-linux-64": "1.20250718.0", "@cloudflare/workerd-linux-arm64": "1.20250718.0", "@cloudflare/workerd-windows-64": "1.20250718.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg=="],
+
+    "wrangler": ["wrangler@3.114.17", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.3.4", "@cloudflare/unenv-preset": "2.0.2", "@esbuild-plugins/node-globals-polyfill": "0.2.3", "@esbuild-plugins/node-modules-polyfill": "0.2.2", "blake3-wasm": "2.1.5", "esbuild": "0.17.19", "miniflare": "3.20250718.3", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.14", "workerd": "1.20250718.0" }, "optionalDependencies": { "fsevents": "~2.3.2", "sharp": "^0.33.5" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250408.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA=="],
+
+    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
+    "youch": ["youch@3.3.4", "", { "dependencies": { "cookie": "^0.7.1", "mustache": "^4.2.0", "stacktracey": "^2.1.8" } }, "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg=="],
+
+    "zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
+  }
+}

--- a/cloudflare/workers/reply-ingress/package.json
+++ b/cloudflare/workers/reply-ingress/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "motzi-reply-ingress",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240925.0",
+    "typescript": "^5.5.0",
+    "wrangler": "^3.80.0"
+  },
+  "dependencies": {
+    "postal-mime": "^2.2.7"
+  }
+}

--- a/cloudflare/workers/reply-ingress/src/index.ts
+++ b/cloudflare/workers/reply-ingress/src/index.ts
@@ -58,6 +58,7 @@ export default {
           Authorization: `Bearer ${env.REPLY_WEBHOOK_SECRET}`,
         },
         body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(10_000),
       });
 
       if (!response.ok) {

--- a/cloudflare/workers/reply-ingress/src/index.ts
+++ b/cloudflare/workers/reply-ingress/src/index.ts
@@ -6,7 +6,7 @@ interface Env {
 }
 
 interface MotziPayload {
-  analysis_id: string;
+  in_reply_to: string;
   from_email: string;
   from_name?: string;
   body: string;
@@ -26,19 +26,19 @@ export default {
         return;
       }
 
-      // 2. Extract analysis_id from recipient address
-      //    Example: reply+analysis-123@thepuff.co
-      const match = message.to.match(/reply\+analysis-(\d+)@/i);
-      if (!match) {
-        message.setReject(`Unknown recipient: ${message.to}`);
-        return;
-      }
-      const analysisId = match[1];
-
-      // 3. Parse the email using postal-mime
+      // 2. Parse the email using postal-mime
       const raw = new Response(message.raw);
       const rawBuffer = await raw.arrayBuffer();
       const parsed = await PostalMime.parse(rawBuffer);
+
+      // 3. Extract In-Reply-To — this is how we identify which analysis
+      //    the reply belongs to. Our mailer sets a stable Message-ID per
+      //    analysis; the replier's client preserves it in In-Reply-To.
+      const inReplyTo = parsed.inReplyTo?.trim() || "";
+      if (!inReplyTo) {
+        message.setReject("Missing In-Reply-To header — not a reply to a known analysis");
+        return;
+      }
 
       const fromEmail = parsed.from?.address || "";
       const fromName = parsed.from?.name || "";
@@ -51,7 +51,7 @@ export default {
 
       // 4. POST to Motzi
       const payload: MotziPayload = {
-        analysis_id: analysisId,
+        in_reply_to: inReplyTo,
         from_email: fromEmail,
         from_name: fromName,
         body: bodyText,

--- a/cloudflare/workers/reply-ingress/src/index.ts
+++ b/cloudflare/workers/reply-ingress/src/index.ts
@@ -17,43 +17,35 @@ interface MotziPayload {
 export default {
   async email(message: ForwardableEmailMessage, env: Env, ctx: ExecutionContext): Promise<void> {
     try {
-      // 1. Verify SPF and DKIM via Authentication-Results
+      // Require either SPF or DKIM to pass — forwarding (e.g. custom-domain
+      // relays) often breaks SPF while preserving DKIM, so AND would reject
+      // legitimate replies.
       const authResults = message.headers.get("Authentication-Results") || "";
-      const spfPass = /spf=pass/i.test(authResults);
-      const dkimPass = /dkim=pass/i.test(authResults);
-      if (!spfPass || !dkimPass) {
-        message.setReject("SPF or DKIM verification failed");
+      if (!/spf=pass/i.test(authResults) && !/dkim=pass/i.test(authResults)) {
+        message.setReject("SPF and DKIM verification failed");
         return;
       }
 
-      // 2. Parse the email using postal-mime
-      const raw = new Response(message.raw);
-      const rawBuffer = await raw.arrayBuffer();
+      const rawBuffer = await new Response(message.raw).arrayBuffer();
       const parsed = await PostalMime.parse(rawBuffer);
 
-      // 3. Extract In-Reply-To — this is how we identify which analysis
-      //    the reply belongs to. Our mailer sets a stable Message-ID per
-      //    analysis; the replier's client preserves it in In-Reply-To.
       const inReplyTo = parsed.inReplyTo?.trim() || "";
-      if (!inReplyTo) {
-        message.setReject("Missing In-Reply-To header — not a reply to a known analysis");
-        return;
-      }
-
       const fromEmail = parsed.from?.address || "";
-      const fromName = parsed.from?.name || "";
       const bodyText = parsed.text || "";
 
+      if (!inReplyTo) {
+        message.setReject("Missing In-Reply-To — not a reply to a known analysis");
+        return;
+      }
       if (!fromEmail || !bodyText) {
         message.setReject("Missing From address or body");
         return;
       }
 
-      // 4. POST to Motzi
       const payload: MotziPayload = {
         in_reply_to: inReplyTo,
         from_email: fromEmail,
-        from_name: fromName,
+        from_name: parsed.from?.name || "",
         body: bodyText,
         message_id: parsed.messageId,
         subject: parsed.subject,
@@ -73,9 +65,7 @@ export default {
         try {
           const json = (await response.json()) as { error?: string };
           if (json.error) reason = json.error;
-        } catch {
-          // ignore parse errors
-        }
+        } catch { /* non-JSON body */ }
         message.setReject(reason);
       }
     } catch (err) {

--- a/cloudflare/workers/reply-ingress/src/index.ts
+++ b/cloudflare/workers/reply-ingress/src/index.ts
@@ -1,0 +1,86 @@
+import PostalMime from "postal-mime";
+
+interface Env {
+  MOTZI_URL: string;
+  REPLY_WEBHOOK_SECRET: string;
+}
+
+interface MotziPayload {
+  analysis_id: string;
+  from_email: string;
+  from_name?: string;
+  body: string;
+  message_id?: string;
+  subject?: string;
+}
+
+export default {
+  async email(message: ForwardableEmailMessage, env: Env, ctx: ExecutionContext): Promise<void> {
+    try {
+      // 1. Verify SPF and DKIM via Authentication-Results
+      const authResults = message.headers.get("Authentication-Results") || "";
+      const spfPass = /spf=pass/i.test(authResults);
+      const dkimPass = /dkim=pass/i.test(authResults);
+      if (!spfPass || !dkimPass) {
+        message.setReject("SPF or DKIM verification failed");
+        return;
+      }
+
+      // 2. Extract analysis_id from recipient address
+      //    Example: reply+analysis-123@thepuff.co
+      const match = message.to.match(/reply\+analysis-(\d+)@/i);
+      if (!match) {
+        message.setReject(`Unknown recipient: ${message.to}`);
+        return;
+      }
+      const analysisId = match[1];
+
+      // 3. Parse the email using postal-mime
+      const raw = new Response(message.raw);
+      const rawBuffer = await raw.arrayBuffer();
+      const parsed = await PostalMime.parse(rawBuffer);
+
+      const fromEmail = parsed.from?.address || "";
+      const fromName = parsed.from?.name || "";
+      const bodyText = parsed.text || "";
+
+      if (!fromEmail || !bodyText) {
+        message.setReject("Missing From address or body");
+        return;
+      }
+
+      // 4. POST to Motzi
+      const payload: MotziPayload = {
+        analysis_id: analysisId,
+        from_email: fromEmail,
+        from_name: fromName,
+        body: bodyText,
+        message_id: parsed.messageId,
+        subject: parsed.subject,
+      };
+
+      const response = await fetch(`${env.MOTZI_URL}/reply_ingress`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${env.REPLY_WEBHOOK_SECRET}`,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        let reason = `Motzi rejected the reply (HTTP ${response.status})`;
+        try {
+          const json = (await response.json()) as { error?: string };
+          if (json.error) reason = json.error;
+        } catch {
+          // ignore parse errors
+        }
+        message.setReject(reason);
+      }
+    } catch (err) {
+      console.error("reply-ingress error", err);
+      message.setReject("Internal worker error — check logs");
+    }
+  },
+};

--- a/cloudflare/workers/reply-ingress/tsconfig.json
+++ b/cloudflare/workers/reply-ingress/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "lib": ["es2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/cloudflare/workers/reply-ingress/wrangler.toml
+++ b/cloudflare/workers/reply-ingress/wrangler.toml
@@ -2,6 +2,10 @@ name = "motzi-reply-ingress"
 main = "src/index.ts"
 compatibility_date = "2024-10-01"
 
+# Email-only worker — no public HTTP surface.
+workers_dev = false
+preview_urls = false
+
 [vars]
 MOTZI_URL = "https://motzibread.herokuapp.com"
 

--- a/cloudflare/workers/reply-ingress/wrangler.toml
+++ b/cloudflare/workers/reply-ingress/wrangler.toml
@@ -1,0 +1,9 @@
+name = "motzi-reply-ingress"
+main = "src/index.ts"
+compatibility_date = "2024-10-01"
+
+[vars]
+MOTZI_URL = "https://motzibread.herokuapp.com"
+
+# Secrets — set via: wrangler secret put REPLY_WEBHOOK_SECRET
+# - REPLY_WEBHOOK_SECRET

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,8 @@ Rails.application.routes.draw do
     mount MissionControl::Jobs::Engine, at: "/jobs"
   end
 
+  post "/reply_ingress", to: "reply_ingress#create"
+
   # Error feedback API (used by error pages)
   namespace :api do
     resources :feedbacks, only: [:create]

--- a/db/migrate/20260413035352_create_analysis_replies.rb
+++ b/db/migrate/20260413035352_create_analysis_replies.rb
@@ -1,0 +1,17 @@
+class CreateAnalysisReplies < ActiveRecord::Migration[7.2]
+  def change
+    create_table :analysis_replies do |t|
+      t.references :anomaly_analysis, null: false, foreign_key: true, index: true
+      t.references :user, null: true, foreign_key: true, index: true
+      t.string :author_email, null: false
+      t.string :author_name
+      t.text :body, null: false
+      t.string :message_id
+      t.integer :source, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :analysis_replies, :message_id, unique: true
+  end
+end

--- a/db/migrate/20260413044025_add_email_message_id_to_anomaly_analyses.rb
+++ b/db/migrate/20260413044025_add_email_message_id_to_anomaly_analyses.rb
@@ -1,0 +1,6 @@
+class AddEmailMessageIdToAnomalyAnalyses < ActiveRecord::Migration[7.2]
+  def change
+    add_column :anomaly_analyses, :email_message_id, :string
+    add_index :anomaly_analyses, :email_message_id, unique: true
+  end
+end

--- a/db/migrate/20260413044025_add_email_message_id_to_anomaly_analyses.rb
+++ b/db/migrate/20260413044025_add_email_message_id_to_anomaly_analyses.rb
@@ -1,6 +1,0 @@
-class AddEmailMessageIdToAnomalyAnalyses < ActiveRecord::Migration[7.2]
-  def change
-    add_column :anomaly_analyses, :email_message_id, :string
-    add_index :anomaly_analyses, :email_message_id, unique: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_13_035352) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_13_044025) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -165,6 +165,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_13_035352) do
     t.string "api_model"
     t.integer "cost_cents"
     t.string "overall_status"
+    t.string "email_message_id"
+    t.index ["email_message_id"], name: "index_anomaly_analyses_on_email_message_id", unique: true
     t.index ["user_id"], name: "index_anomaly_analyses_on_user_id"
     t.index ["week_id"], name: "index_anomaly_analyses_on_week_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_12_151138) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_13_035352) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -131,6 +131,21 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_151138) do
     t.datetime "started_at", precision: nil
     t.index ["user_id"], name: "index_ahoy_visits_on_user_id"
     t.index ["visit_token"], name: "index_ahoy_visits_on_visit_token", unique: true
+  end
+
+  create_table "analysis_replies", force: :cascade do |t|
+    t.bigint "anomaly_analysis_id", null: false
+    t.bigint "user_id"
+    t.string "author_email", null: false
+    t.string "author_name"
+    t.text "body", null: false
+    t.string "message_id"
+    t.integer "source", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["anomaly_analysis_id"], name: "index_analysis_replies_on_anomaly_analysis_id"
+    t.index ["message_id"], name: "index_analysis_replies_on_message_id", unique: true
+    t.index ["user_id"], name: "index_analysis_replies_on_user_id"
   end
 
   create_table "anomaly_analyses", force: :cascade do |t|
@@ -530,6 +545,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_151138) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "activity_events", "users"
+  add_foreign_key "analysis_replies", "anomaly_analyses"
+  add_foreign_key "analysis_replies", "users"
   add_foreign_key "anomaly_analyses", "users"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_13_044025) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_13_035352) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -165,8 +165,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_13_044025) do
     t.string "api_model"
     t.integer "cost_cents"
     t.string "overall_status"
-    t.string "email_message_id"
-    t.index ["email_message_id"], name: "index_anomaly_analyses_on_email_message_id", unique: true
     t.index ["user_id"], name: "index_anomaly_analyses_on_user_id"
     t.index ["week_id"], name: "index_anomaly_analyses_on_week_id"
   end

--- a/test/controllers/reply_ingress_controller_test.rb
+++ b/test/controllers/reply_ingress_controller_test.rb
@@ -5,7 +5,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
     @secret = "test-secret-123"
     ENV["REPLY_WEBHOOK_SECRET"] = @secret
     @analysis = anomaly_analyses(:week1_analysis)
-    @analysis.update!(email_message_id: "<analysis-#{@analysis.id}-testabc@motzibread.herokuapp.com>")
+    @in_reply_to = "<analysis-#{@analysis.id}@motzibread.herokuapp.com>"
     @admin = users(:kyle)  # kyle fixture is an admin
   end
 
@@ -21,7 +21,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
     assert_difference "AnalysisReply.count", 1 do
       post "/reply_ingress",
         params: {
-          in_reply_to: @analysis.email_message_id,
+          in_reply_to: @in_reply_to,
           from_email: @admin.email,
           from_name: @admin.name,
           body: "R14 isn't an error. Please stop flagging it.",
@@ -41,7 +41,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
 
   test "401 without auth header" do
     post "/reply_ingress",
-      params: { in_reply_to: @analysis.email_message_id }.to_json,
+      params: { in_reply_to: @in_reply_to }.to_json,
       headers: { "Content-Type" => "application/json" }
 
     assert_response :unauthorized
@@ -49,7 +49,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
 
   test "401 with wrong secret" do
     post "/reply_ingress",
-      params: { in_reply_to: @analysis.email_message_id }.to_json,
+      params: { in_reply_to: @in_reply_to }.to_json,
       headers: { "Authorization" => "Bearer nope", "Content-Type" => "application/json" }
 
     assert_response :unauthorized
@@ -74,7 +74,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference "AnalysisReply.count" do
       post "/reply_ingress",
         params: {
-          in_reply_to: @analysis.email_message_id,
+          in_reply_to: @in_reply_to,
           from_email: non_admin.email,
           body: "hi"
         }.to_json,
@@ -88,7 +88,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference "AnalysisReply.count" do
       post "/reply_ingress",
         params: {
-          in_reply_to: @analysis.email_message_id,
+          in_reply_to: @in_reply_to,
           from_email: "randomstranger@example.com",
           body: "hi"
         }.to_json,
@@ -100,7 +100,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
 
   test "duplicate message_id returns 200 idempotent" do
     payload = {
-      in_reply_to: @analysis.email_message_id,
+      in_reply_to: @in_reply_to,
       from_email: @admin.email,
       body: "first",
       message_id: "<dup@example.com>"
@@ -128,7 +128,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
 
     post "/reply_ingress",
       params: {
-        in_reply_to: @analysis.email_message_id,
+        in_reply_to: @in_reply_to,
         from_email: @admin.email,
         body: body_with_quote,
         message_id: "<strip-test@example.com>"

--- a/test/controllers/reply_ingress_controller_test.rb
+++ b/test/controllers/reply_ingress_controller_test.rb
@@ -117,6 +117,33 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
     assert_equal "duplicate", json["status"]
   end
 
+  test "401 (not 500) when Authorization token is a different length than expected" do
+    post "/reply_ingress",
+      params: { in_reply_to: @in_reply_to }.to_json,
+      headers: { "Authorization" => "Bearer x", "Content-Type" => "application/json" }
+
+    assert_response :unauthorized
+  end
+
+  test "422 when reply body is empty after stripping quoted history" do
+    quote_only_body = <<~BODY
+      On Sun, Apr 12, 2026 at 9:00 PM Motzi <no-reply@motzi.com> wrote:
+      > nothing here but the quote
+    BODY
+
+    assert_no_difference "AnalysisReply.count" do
+      post "/reply_ingress",
+        params: {
+          in_reply_to: @in_reply_to,
+          from_email: @admin.email,
+          body: quote_only_body
+        }.to_json,
+        headers: auth_headers
+    end
+
+    assert_response :unprocessable_entity
+  end
+
   test "strips quoted reply history from body" do
     body_with_quote = <<~BODY
       Here is my new thought.

--- a/test/controllers/reply_ingress_controller_test.rb
+++ b/test/controllers/reply_ingress_controller_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @secret = "test-secret-123"
+    ENV["REPLY_WEBHOOK_SECRET"] = @secret
+    @analysis = anomaly_analyses(:week1_analysis)
+    @admin = users(:kyle)  # kyle fixture is an admin
+  end
+
+  teardown do
+    ENV.delete("REPLY_WEBHOOK_SECRET")
+  end
+
+  def auth_headers
+    { "Authorization" => "Bearer #{@secret}", "Content-Type" => "application/json" }
+  end
+
+  test "creates a reply for an admin sender" do
+    assert_difference "AnalysisReply.count", 1 do
+      post "/reply_ingress",
+        params: {
+          analysis_id: @analysis.id,
+          from_email: @admin.email,
+          from_name: @admin.name,
+          body: "R14 isn't an error. Please stop flagging it.",
+          message_id: "<unique-id-1@gmail.com>"
+        }.to_json,
+        headers: auth_headers
+    end
+
+    assert_response :created
+    reply = AnalysisReply.last
+    assert_equal @analysis, reply.anomaly_analysis
+    assert_equal @admin, reply.user
+    assert_equal @admin.email, reply.author_email
+    assert_equal "<unique-id-1@gmail.com>", reply.message_id
+    assert reply.email?
+  end
+end

--- a/test/controllers/reply_ingress_controller_test.rb
+++ b/test/controllers/reply_ingress_controller_test.rb
@@ -5,6 +5,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
     @secret = "test-secret-123"
     ENV["REPLY_WEBHOOK_SECRET"] = @secret
     @analysis = anomaly_analyses(:week1_analysis)
+    @analysis.update!(email_message_id: "<analysis-#{@analysis.id}-testabc@motzibread.herokuapp.com>")
     @admin = users(:kyle)  # kyle fixture is an admin
   end
 
@@ -20,7 +21,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
     assert_difference "AnalysisReply.count", 1 do
       post "/reply_ingress",
         params: {
-          analysis_id: @analysis.id,
+          in_reply_to: @analysis.email_message_id,
           from_email: @admin.email,
           from_name: @admin.name,
           body: "R14 isn't an error. Please stop flagging it.",
@@ -40,7 +41,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
 
   test "401 without auth header" do
     post "/reply_ingress",
-      params: { analysis_id: @analysis.id }.to_json,
+      params: { in_reply_to: @analysis.email_message_id }.to_json,
       headers: { "Content-Type" => "application/json" }
 
     assert_response :unauthorized
@@ -48,7 +49,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
 
   test "401 with wrong secret" do
     post "/reply_ingress",
-      params: { analysis_id: @analysis.id }.to_json,
+      params: { in_reply_to: @analysis.email_message_id }.to_json,
       headers: { "Authorization" => "Bearer nope", "Content-Type" => "application/json" }
 
     assert_response :unauthorized
@@ -57,7 +58,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
   test "404 when analysis does not exist" do
     post "/reply_ingress",
       params: {
-        analysis_id: 999_999,
+        in_reply_to: "<unknown-missing@example.com>",
         from_email: @admin.email,
         body: "hi"
       }.to_json,
@@ -73,7 +74,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference "AnalysisReply.count" do
       post "/reply_ingress",
         params: {
-          analysis_id: @analysis.id,
+          in_reply_to: @analysis.email_message_id,
           from_email: non_admin.email,
           body: "hi"
         }.to_json,
@@ -87,7 +88,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference "AnalysisReply.count" do
       post "/reply_ingress",
         params: {
-          analysis_id: @analysis.id,
+          in_reply_to: @analysis.email_message_id,
           from_email: "randomstranger@example.com",
           body: "hi"
         }.to_json,
@@ -99,7 +100,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
 
   test "duplicate message_id returns 200 idempotent" do
     payload = {
-      analysis_id: @analysis.id,
+      in_reply_to: @analysis.email_message_id,
       from_email: @admin.email,
       body: "first",
       message_id: "<dup@example.com>"
@@ -127,7 +128,7 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
 
     post "/reply_ingress",
       params: {
-        analysis_id: @analysis.id,
+        in_reply_to: @analysis.email_message_id,
         from_email: @admin.email,
         body: body_with_quote,
         message_id: "<strip-test@example.com>"

--- a/test/controllers/reply_ingress_controller_test.rb
+++ b/test/controllers/reply_ingress_controller_test.rb
@@ -37,4 +37,105 @@ class ReplyIngressControllerTest < ActionDispatch::IntegrationTest
     assert_equal "<unique-id-1@gmail.com>", reply.message_id
     assert reply.email?
   end
+
+  test "401 without auth header" do
+    post "/reply_ingress",
+      params: { analysis_id: @analysis.id }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :unauthorized
+  end
+
+  test "401 with wrong secret" do
+    post "/reply_ingress",
+      params: { analysis_id: @analysis.id }.to_json,
+      headers: { "Authorization" => "Bearer nope", "Content-Type" => "application/json" }
+
+    assert_response :unauthorized
+  end
+
+  test "404 when analysis does not exist" do
+    post "/reply_ingress",
+      params: {
+        analysis_id: 999_999,
+        from_email: @admin.email,
+        body: "hi"
+      }.to_json,
+      headers: auth_headers
+
+    assert_response :not_found
+  end
+
+  test "403 when sender is not an admin" do
+    non_admin = users(:jess)
+    assert_not non_admin.is_admin?, "jess fixture should not be admin"
+
+    assert_no_difference "AnalysisReply.count" do
+      post "/reply_ingress",
+        params: {
+          analysis_id: @analysis.id,
+          from_email: non_admin.email,
+          body: "hi"
+        }.to_json,
+        headers: auth_headers
+    end
+
+    assert_response :forbidden
+  end
+
+  test "403 when sender email is unknown" do
+    assert_no_difference "AnalysisReply.count" do
+      post "/reply_ingress",
+        params: {
+          analysis_id: @analysis.id,
+          from_email: "randomstranger@example.com",
+          body: "hi"
+        }.to_json,
+        headers: auth_headers
+    end
+
+    assert_response :forbidden
+  end
+
+  test "duplicate message_id returns 200 idempotent" do
+    payload = {
+      analysis_id: @analysis.id,
+      from_email: @admin.email,
+      body: "first",
+      message_id: "<dup@example.com>"
+    }
+    post "/reply_ingress", params: payload.to_json, headers: auth_headers
+    assert_response :created
+
+    assert_no_difference "AnalysisReply.count" do
+      post "/reply_ingress", params: payload.to_json, headers: auth_headers
+    end
+
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert_equal "duplicate", json["status"]
+  end
+
+  test "strips quoted reply history from body" do
+    body_with_quote = <<~BODY
+      Here is my new thought.
+
+      On Sun, Apr 12, 2026 at 9:00 PM Motzi <no-reply@motzi.com> wrote:
+      > old stuff
+      > more old stuff
+    BODY
+
+    post "/reply_ingress",
+      params: {
+        analysis_id: @analysis.id,
+        from_email: @admin.email,
+        body: body_with_quote,
+        message_id: "<strip-test@example.com>"
+      }.to_json,
+      headers: auth_headers
+
+    assert_response :created
+    reply = AnalysisReply.last
+    assert_equal "Here is my new thought.", reply.body
+  end
 end

--- a/test/fixtures/anomaly_analyses.yml
+++ b/test/fixtures/anomaly_analyses.yml
@@ -3,6 +3,7 @@ week1_analysis:
   result: |
     Status: ✅ Healthy
     Everything looks fine this week.
+  overall_status: healthy
   trigger: scheduled
   model_used: claude-sonnet-4-6
   input_tokens: 1000

--- a/test/fixtures/anomaly_analyses.yml
+++ b/test/fixtures/anomaly_analyses.yml
@@ -1,1 +1,10 @@
-# empty — tests create their own records
+week1_analysis:
+  week_id: 19w01
+  result: |
+    Status: ✅ Healthy
+    Everything looks fine this week.
+  trigger: scheduled
+  model_used: claude-sonnet-4-6
+  input_tokens: 1000
+  output_tokens: 200
+  cost_cents: 10

--- a/test/mailers/anomaly_mailer_test.rb
+++ b/test/mailers/anomaly_mailer_test.rb
@@ -36,10 +36,30 @@ class AnomalyMailerTest < ActionMailer::TestCase
     assert_includes html, "activity_feed"
   end
 
-  test "sets Reply-To with analysis ID for replies" do
+  test "sets Reply-To to the shared replies address" do
     analysis = anomaly_analyses(:week1_analysis)
     email = AnomalyMailer.with(analysis: analysis).anomaly_report
 
-    assert_equal ["reply+analysis-#{analysis.id}@thepuff.co"], email.reply_to
+    assert_equal ["motzi-analysis-replies@thepuff.co"], email.reply_to
+  end
+
+  test "sets a stable Message-ID and persists it on the analysis" do
+    analysis = anomaly_analyses(:week1_analysis)
+    analysis.update!(email_message_id: nil)
+
+    email = AnomalyMailer.with(analysis: analysis).anomaly_report
+    email.message_id # force header generation
+
+    analysis.reload
+    assert analysis.email_message_id.present?, "expected email_message_id to be stored"
+    assert_equal analysis.email_message_id, "<#{email.message_id}>"
+  end
+
+  test "reuses stored Message-ID on subsequent deliveries" do
+    analysis = anomaly_analyses(:week1_analysis)
+    analysis.update!(email_message_id: "<fixed-id@example.com>")
+
+    email = AnomalyMailer.with(analysis: analysis).anomaly_report
+    assert_equal "fixed-id@example.com", email.message_id
   end
 end

--- a/test/mailers/anomaly_mailer_test.rb
+++ b/test/mailers/anomaly_mailer_test.rb
@@ -43,23 +43,10 @@ class AnomalyMailerTest < ActionMailer::TestCase
     assert_equal ["motzi-analysis-replies@thepuff.co"], email.reply_to
   end
 
-  test "sets a stable Message-ID and persists it on the analysis" do
+  test "sets a deterministic Message-ID derived from the analysis id" do
     analysis = anomaly_analyses(:week1_analysis)
-    analysis.update!(email_message_id: nil)
-
     email = AnomalyMailer.with(analysis: analysis).anomaly_report
-    email.message_id # force header generation
 
-    analysis.reload
-    assert analysis.email_message_id.present?, "expected email_message_id to be stored"
-    assert_equal analysis.email_message_id, "<#{email.message_id}>"
-  end
-
-  test "reuses stored Message-ID on subsequent deliveries" do
-    analysis = anomaly_analyses(:week1_analysis)
-    analysis.update!(email_message_id: "<fixed-id@example.com>")
-
-    email = AnomalyMailer.with(analysis: analysis).anomaly_report
-    assert_equal "fixed-id@example.com", email.message_id
+    assert_equal "analysis-#{analysis.id}@motzibread.herokuapp.com", email.message_id
   end
 end

--- a/test/mailers/anomaly_mailer_test.rb
+++ b/test/mailers/anomaly_mailer_test.rb
@@ -35,4 +35,11 @@ class AnomalyMailerTest < ActionMailer::TestCase
     assert_includes html, "View in Admin"
     assert_includes html, "activity_feed"
   end
+
+  test "sets Reply-To with analysis ID for replies" do
+    analysis = anomaly_analyses(:week1_analysis)
+    email = AnomalyMailer.with(analysis: analysis).anomaly_report
+
+    assert_equal ["reply+analysis-#{analysis.id}@thepuff.co"], email.reply_to
+  end
 end

--- a/test/models/analysis_reply_test.rb
+++ b/test/models/analysis_reply_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+
+class AnalysisReplyTest < ActiveSupport::TestCase
+  test "valid with all required attributes" do
+    reply = AnalysisReply.new(
+      anomaly_analysis: anomaly_analyses(:week1_analysis),
+      author_email: "kyle@example.com",
+      body: "R14 isn't an error, ignore it.",
+      source: :email
+    )
+    assert reply.valid?
+  end
+
+  test "invalid without body" do
+    reply = AnalysisReply.new(
+      anomaly_analysis: anomaly_analyses(:week1_analysis),
+      author_email: "kyle@example.com"
+    )
+    refute reply.valid?
+    assert_includes reply.errors[:body], "can't be blank"
+  end
+
+  test "invalid without author_email" do
+    reply = AnalysisReply.new(
+      anomaly_analysis: anomaly_analyses(:week1_analysis),
+      body: "Some feedback"
+    )
+    refute reply.valid?
+    assert_includes reply.errors[:author_email], "can't be blank"
+  end
+
+  test "enforces unique message_id when present" do
+    AnalysisReply.create!(
+      anomaly_analysis: anomaly_analyses(:week1_analysis),
+      author_email: "kyle@example.com",
+      body: "First",
+      message_id: "<abc123@gmail.com>"
+    )
+    dup = AnalysisReply.new(
+      anomaly_analysis: anomaly_analyses(:week1_analysis),
+      author_email: "kyle@example.com",
+      body: "Dup",
+      message_id: "<abc123@gmail.com>"
+    )
+    refute dup.valid?
+  end
+
+  test "allows multiple replies with null message_id" do
+    AnalysisReply.create!(
+      anomaly_analysis: anomaly_analyses(:week1_analysis),
+      author_email: "kyle@example.com",
+      body: "First"
+    )
+    second = AnalysisReply.new(
+      anomaly_analysis: anomaly_analyses(:week1_analysis),
+      author_email: "kyle@example.com",
+      body: "Second"
+    )
+    assert second.valid?
+  end
+
+  test "source enum" do
+    reply = AnalysisReply.new(source: :email)
+    assert reply.email?
+    reply.source = :admin
+    assert reply.admin?
+  end
+end

--- a/test/models/analysis_reply_test.rb
+++ b/test/models/analysis_reply_test.rb
@@ -29,20 +29,21 @@ class AnalysisReplyTest < ActiveSupport::TestCase
     assert_includes reply.errors[:author_email], "can't be blank"
   end
 
-  test "enforces unique message_id when present" do
+  test "DB enforces unique message_id when present" do
     AnalysisReply.create!(
       anomaly_analysis: anomaly_analyses(:week1_analysis),
       author_email: "kyle@example.com",
       body: "First",
       message_id: "<abc123@gmail.com>"
     )
-    dup = AnalysisReply.new(
-      anomaly_analysis: anomaly_analyses(:week1_analysis),
-      author_email: "kyle@example.com",
-      body: "Dup",
-      message_id: "<abc123@gmail.com>"
-    )
-    refute dup.valid?
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      AnalysisReply.create!(
+        anomaly_analysis: anomaly_analyses(:week1_analysis),
+        author_email: "kyle@example.com",
+        body: "Dup",
+        message_id: "<abc123@gmail.com>"
+      )
+    end
   end
 
   test "allows multiple replies with null message_id" do

--- a/test/models/anomaly_analysis_test.rb
+++ b/test/models/anomaly_analysis_test.rb
@@ -36,4 +36,21 @@ class AnomalyAnalysisTest < ActiveSupport::TestCase
     assert analysis.persisted?
     assert_nil analysis.user
   end
+
+  test "has many replies ordered by created_at" do
+    analysis = anomaly_analyses(:week1_analysis)
+    first = analysis.replies.create!(author_email: "kyle@example.com", body: "first", created_at: 2.hours.ago)
+    second = analysis.replies.create!(author_email: "kyle@example.com", body: "second", created_at: 1.hour.ago)
+
+    assert_equal [first, second], analysis.replies.to_a
+  end
+
+  test "destroys replies when analysis is destroyed" do
+    analysis = anomaly_analyses(:week1_analysis)
+    analysis.replies.create!(author_email: "kyle@example.com", body: "bye")
+
+    assert_difference "AnalysisReply.count", -1 do
+      analysis.destroy
+    end
+  end
 end

--- a/test/services/anomaly_detector_integration_test.rb
+++ b/test/services/anomaly_detector_integration_test.rb
@@ -35,4 +35,23 @@ class AnomalyDetectorIntegrationTest < ActiveSupport::TestCase
     assert_includes prompt, "Whether recent code changes could plausibly explain the behavior you see this week"
     assert_includes prompt, "Treat code changes as supporting evidence, not proof"
   end
+
+  test "build_user_message includes replies alongside prior analyses" do
+    prior_week_id = "19w01"  # matches week1_analysis fixture
+    prior = anomaly_analyses(:week1_analysis)
+    prior.replies.create!(
+      author_email: "kyle@example.com",
+      author_name: "Kyle Fritz",
+      body: "R14 is expected — please stop flagging it.",
+      source: :email
+    )
+
+    detector = AnomalyDetector.new(prior_week_id)
+    message = detector.build_user_message
+
+    assert_includes message, "R14 is expected",
+      "expected reply body to appear in the prompt"
+    assert_includes message, "Operator replies",
+      "expected an Operator replies heading"
+  end
 end


### PR DESCRIPTION
## Summary

Reply to the weekly Activity Report email and the reply becomes an `AnalysisReply` fed back into next week's prompt. The address is `motzi-analysis-replies@thepuff.co`; replies are matched to their analysis via the `In-Reply-To` header (Cloudflare custom addresses are exact-match and don't support plus-addressing, so the analysis id is encoded in a deterministic per-analysis `Message-ID` instead).

## Changes

**Rails**
- `analysis_replies` table + model, `has_many :replies` on `AnomalyAnalysis`
- `AnomalyMailer`: deterministic `<analysis-{id}@motzibread.herokuapp.com>` Message-ID; `Reply-To: motzi-analysis-replies@thepuff.co`
- `ReplyIngressController`: Bearer-auth webhook, admin-only sender validation, idempotent on duplicate, strips quoted history; 401 on length-mismatched token, 422 on empty body after stripping
- `AnomalyDetector#build_user_message` includes operator replies under each prior analysis (`includes(:replies)`)
- Activity Feed panel renders replies under each Claude analysis

**Worker** (`cloudflare/workers/reply-ingress/`)
- TypeScript email handler, deployed as `motzi-reply-ingress`
- SPF **or** DKIM pass (AND would reject legitimate forwarded replies)
- Parses `In-Reply-To`, POSTs to Rails with 10s timeout
- `workers_dev = false` — email-only, no public HTTP surface

## Deploy checklist
- [x] `wrangler secret put REPLY_WEBHOOK_SECRET`
- [x] `wrangler deploy`
- [x] Cloudflare Email Routing: \`motzi-analysis-replies@thepuff.co\` → \`motzi-reply-ingress\`
- [x] \`heroku config:set REPLY_WEBHOOK_SECRET=...\` (matches wrangler)
- [ ] After merge: run the test plan below

## Manual test plan

### Setup
- [ ] \`gh run list --branch master --limit 3\` — confirm Rails deploy green
- [ ] \`cd cloudflare/workers/reply-ingress && wrangler tail\` — keep worker logs open
- [ ] Trigger a report: \`heroku run rails runner 'AnomalyDetectorJob.perform_now' --app motzibread\`
- [ ] In the received email, inspect raw headers — confirm \`Reply-To: motzi-analysis-replies@thepuff.co\` and \`Message-ID: <analysis-{id}@motzibread.herokuapp.com>\`

### Test cases

1. **Happy path**
   - [ ] Reply from admin address: "Test reply — ignore this"
   - [ ] Worker log: POST to \`/reply_ingress\`, Rails returns \`201\`
   - [ ] Admin Activity Feed shows the reply under that analysis card (name, timestamp, "via email")
   - [ ] \`AnalysisReply.last.body\` equals the fresh text only (no quoted original)

2. **Quote stripping**
   - [ ] Reply with fresh text followed by auto-inserted quote block
   - [ ] Reply appears with ONLY the fresh text

3. **Quote-only reply (graceful reject)**
   - [ ] Reply without typing anything new
   - [ ] Worker: \`setReject\` → bounce email received
   - [ ] No \`AnalysisReply\` row created

4. **Non-admin sender**
   - [ ] Reply from an address not registered as admin in \`User\`
   - [ ] Worker: 403 / "Sender not authorized" → bounce
   - [ ] No reply in admin

5. **Random email (no In-Reply-To)**
   - [ ] Compose a NEW email to \`motzi-analysis-replies@thepuff.co\`
   - [ ] Worker: "Missing In-Reply-To" → bounce

6. **Direct webhook hit without auth**
   - [ ] \`curl -X POST https://motzibread.herokuapp.com/reply_ingress -d '{}'\` → 401

7. **Prompt feedback loop**
   - [ ] After case 1 succeeds, trigger another analysis
   - [ ] New analysis's prompt includes "**Operator replies:**" with the reply body under the prior analysis

## Rollback

If anything breaks in prod: disable the Cloudflare Email Routing rule (dashboard toggle) and revert the PR merge. Heroku rolls back automatically on revert push.

## Known follow-ups (separate issues)
- Add a test suite for the Cloudflare Worker (currently no tests)
- Consider \`email_reply_parser\` gem for robust quote stripping across more clients
- Cloudflare Queue for retries if Rails is down during a reply delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)