### PR TITLE
Improve email authentication verification in reply ingress worker

### DIFF
--- a/cloudflare/workers/reply-ingress/README.md
+++ b/cloudflare/workers/reply-ingress/README.md
@@ -7,7 +7,7 @@ Cloudflare Email Worker that receives replies to the Motzi Activity Report email
 1. Motzi's `AnomalyMailer` sends each weekly Activity Report with a stable `Message-ID` (persisted on the `AnomalyAnalysis` as `email_message_id`) and `Reply-To: motzi-analysis-replies@thepuff.co`.
 2. User replies — their email client preserves the original Message-ID in `In-Reply-To`.
 3. Cloudflare Email Routing forwards `motzi-analysis-replies@thepuff.co` to this worker.
-4. Worker verifies SPF and DKIM, parses the MIME via `postal-mime`, and POSTs the `In-Reply-To` value plus sender/body to `${MOTZI_URL}/reply_ingress` with a Bearer token.
+4. Worker verifies authentication (accepts any of SPF, DKIM, or DMARC pass — reading Cloudflare's `ARC-Authentication-Results` header), parses the MIME via `postal-mime`, and POSTs the `In-Reply-To` value plus sender/body to `${MOTZI_URL}/reply_ingress` with a Bearer token.
 5. Motzi looks up the analysis by `email_message_id`, validates the sender is an admin, and creates an `AnalysisReply`.
 6. If anything fails (SPF, DKIM, unknown analysis, non-admin sender, Motzi error), the worker calls `message.setReject(reason)` and Cloudflare bounces the email back to the sender.
 

--- a/cloudflare/workers/reply-ingress/src/index.ts
+++ b/cloudflare/workers/reply-ingress/src/index.ts
@@ -15,14 +15,34 @@ interface MotziPayload {
 }
 
 export default {
-  async email(message: ForwardableEmailMessage, env: Env, ctx: ExecutionContext): Promise<void> {
+  async email(
+    message: ForwardableEmailMessage,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<void> {
     try {
-      // Require either SPF or DKIM to pass — forwarding (e.g. custom-domain
-      // relays) often breaks SPF while preserving DKIM, so AND would reject
-      // legitimate replies.
-      const authResults = message.headers.get("Authentication-Results") || "";
-      if (!/spf=pass/i.test(authResults) && !/dkim=pass/i.test(authResults)) {
-        message.setReject("SPF and DKIM verification failed");
+      // Cloudflare stamps its own auth verdict into `ARC-Authentication-Results`
+      // with authserv-id `mx.cloudflare.net`. The plain `Authentication-Results`
+      // header, if present, was added by some upstream hop (e.g. the sender's
+      // own outbound gateway) and can't be trusted here. Prefer CF's header and
+      // only fall back to the generic one so self-hosted test setups keep
+      // working.
+      //
+      // Accept if DMARC, SPF, or DKIM passed — forwarding (e.g. custom-domain
+      // relays) often breaks SPF while preserving DKIM, and DMARC alignment is
+      // itself a stronger signal than either alone.
+      const authResults =
+        message.headers.get("ARC-Authentication-Results") ||
+        message.headers.get("Authentication-Results") ||
+        "";
+      const spfPass = /\bspf=pass\b/i.test(authResults);
+      const dkimPass = /\bdkim=pass\b/i.test(authResults);
+      const dmarcPass = /\bdmarc=pass\b/i.test(authResults);
+      if (!spfPass && !dkimPass && !dmarcPass) {
+        const snippet = authResults.slice(0, 200).replace(/\s+/g, " ");
+        message.setReject(
+          `SPF, DKIM, and DMARC verification failed${snippet ? ` (${snippet})` : ""}`,
+        );
         return;
       }
 
@@ -34,7 +54,9 @@ export default {
       const bodyText = parsed.text || "";
 
       if (!inReplyTo) {
-        message.setReject("Missing In-Reply-To — not a reply to a known analysis");
+        message.setReject(
+          "Missing In-Reply-To — not a reply to a known analysis",
+        );
         return;
       }
       if (!fromEmail || !bodyText) {
@@ -66,7 +88,9 @@ export default {
         try {
           const json = (await response.json()) as { error?: string };
           if (json.error) reason = json.error;
-        } catch { /* non-JSON body */ }
+        } catch {
+          /* non-JSON body */
+        }
         message.setReject(reason);
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
Enhanced the email authentication verification logic in the reply ingress worker to be more robust and standards-compliant. The worker now checks Cloudflare's `ARC-Authentication-Results` header as the primary source of truth and accepts emails that pass any of SPF, DKIM, or DMARC verification.

## Key Changes
- **Prefer Cloudflare's ARC header**: Changed to read `ARC-Authentication-Results` (stamped by Cloudflare's mail system) as the primary authentication source, with fallback to the generic `Authentication-Results` header for compatibility with self-hosted test setups
- **Accept multiple auth methods**: Updated logic to accept emails passing SPF, DKIM, OR DMARC (previously required SPF or DKIM only). DMARC alignment is a stronger signal and should be trusted
- **Improved regex matching**: Changed from `/spf=pass/i` to `/\bspf=pass\b/i` (and similar for DKIM/DMARC) to match word boundaries and avoid false positives
- **Better error messages**: Enhanced rejection messages to include a snippet of the authentication results header (first 200 chars) for debugging purposes
- **Code formatting**: Applied consistent formatting to multi-line function signatures and catch blocks

## Implementation Details
- The authentication check now extracts SPF, DKIM, and DMARC pass/fail states into separate boolean variables for clarity
- Error messages now include up to 200 characters of the auth results header (with normalized whitespace) to help diagnose authentication failures
- Updated README to reflect the new authentication strategy

https://claude.ai/code/session_01EMbA8CerDR9HmnZwD8TQKY