### PR TITLE
Boost signal in nightly anomaly reports: failed jobs, bounce data, resolved-error filtering, uptime probe, admin replies

### DIFF
--- a/app/admin/activity_feed.rb
+++ b/app/admin/activity_feed.rb
@@ -22,6 +22,27 @@ ActiveAdmin.register_page "Activity Feed" do
     end
   end
 
+  # Quick operator reply on an analysis — stored like an email reply and fed
+  # into the next analysis prompt, closing the feedback loop without email.
+  page_action :reply, method: :post do
+    analysis = AnomalyAnalysis.find(params[:analysis_id])
+    body = params[:body].to_s.strip
+
+    if body.blank?
+      redirect_to admin_activity_feed_path(week_id: analysis.week_id), alert: "Reply can't be blank."
+    else
+      analysis.replies.create!(
+        user: current_admin_user,
+        author_email: current_admin_user.email,
+        author_name: current_admin_user.name,
+        body: body,
+        source: :admin
+      )
+      redirect_to admin_activity_feed_path(week_id: analysis.week_id),
+        notice: "Reply saved — it will be included in the next analysis prompt."
+    end
+  end
+
   # Analyze with Claude (enqueues background job)
   page_action :analyze, method: :post do
     week_id = params[:week_id] || Time.zone.now.week_id
@@ -560,6 +581,17 @@ ActiveAdmin.register_page "Activity Feed" do
                     end
                   end
                 end
+              end
+            end
+
+            div class: "analysis-reply-form", style: "margin-top: 12px" do
+              form action: admin_activity_feed_reply_path, method: :post do
+                input type: "hidden", name: "authenticity_token", value: form_authenticity_token
+                input type: "hidden", name: "analysis_id", value: analysis.id
+                textarea name: "body", rows: 2,
+                  placeholder: "Acknowledge or correct a finding — your reply is fed into the next analysis",
+                  style: "width: 100%; box-sizing: border-box; font-size: 13px; padding: 6px 8px"
+                button "Reply", type: "submit", style: "margin-top: 4px"
               end
             end
 

--- a/app/prompts/anomaly_detection.txt
+++ b/app/prompts/anomaly_detection.txt
@@ -15,6 +15,9 @@ You are reviewing the activity feed for the current week and comparing it to rec
 - Whether recent code changes could plausibly explain the behavior you see this week
 - Dyno memory pressure (memory_total approaching or exceeding quota, swap usage growth)
 - Application errors and stack traces in the "Application Errors" sections — recurring exceptions, new error types, or error spikes. Two sources are surfaced: "(from Heroku logs)" is log-scraped (lossy, no stack), while "(N events: server/browser/job)" comes from the persisted error_events table and includes top stack frame, source, count, and event id. Cross-reference both. When flagging a specific error, cite the event id so an operator can open `/admin/error_events/<id>` for the full prompt.
+- The "Failed Jobs" section is the authoritative count from solid_queue_failed_executions. "0 failed jobs this week" means exactly that — never speculate about silent or unverifiable job failures when this section says zero.
+- The "Deliverability (SendGrid)" line in Email Health reports provider-side bounce, block, and spam-report counts. Use it to settle deliverability questions directly — do not recommend "check the mail provider for bounces" when this data is present. If it reads "data unavailable", say so once instead of speculating.
+- The "Uptime Probe" section (when present) is a live HTTP check made as this report ran. If it shows a 200, the site was reachable — do not ask the operator to verify site accessibility.
 
 ## Scheduled jobs
 
@@ -40,6 +43,7 @@ The `analyze_anomalies` job is the job generating this report. If it appears as 
 - **Normal memory usage**: Memory usage under 80% of quota is healthy. Brief spikes during job processing are expected. Only flag sustained memory pressure (avg > 80% of quota) or R15 errors (hard kill).
 - **R14 is not an error**: R14 means the dyno exceeded its soft memory limit and went to swap. On Heroku's essential tier this is normal — the process continues running in swap. R14 counts are included in the data for context but should not be flagged as anomalies or elevate the status to Warning. Only R15 (hard memory limit, dyno killed) is a real problem.
 - **Multiple order confirmation emails to the same member**: The order-update endpoint intentionally sends a fresh `ConfirmationMailer#order_email` every time a member edits their order (changes items, quantities, or pickup day). So a member receiving 2–3 order confirmations across a week typically means they edited their order 1–2 times, not that the system is duplicating emails. The activity feed only tags an order confirmation as `[RAPID DUPLICATE]` when two sends land within two minutes of each other — *only* those are worth flagging as a bug. Non-rapid multi-send patterns are expected and should not be called out. Credit-purchase confirmations follow the same rule.
+- **Operator-resolved errors**: Error fingerprints an operator marked resolved in `/admin/error_events` are excluded from the Application Errors section (noted as "N resolved events excluded"). Do not keep flagging an error from prior analyses once it stops appearing — it was triaged. A "[recurred after resolve]" tag means a previously resolved error is happening again; that IS worth flagging.
 - **Things that are working fine**: Do not list normal items just to say they're normal. Only mention healthy metrics if the reader needs context for a related anomaly.
 
 ## Response format

--- a/app/services/activity_feed.rb
+++ b/app/services/activity_feed.rb
@@ -230,6 +230,11 @@ class ActivityFeed
         lines << errors
         lines << ""
       end
+      failed_jobs = failed_jobs_text
+      if failed_jobs
+        lines << failed_jobs
+        lines << ""
+      end
     end
 
     es = email_summary
@@ -249,6 +254,7 @@ class ActivityFeed
         parts << "#{s[:clicked]} clicked" if s[:clicked] > 0
         lines << "#{s[:label]}: #{parts.join(', ')}"
       end
+      lines << deliverability_text
       lines << ""
     end
 
@@ -426,9 +432,15 @@ class ActivityFeed
     lines.join("\n")
   end
 
+  # Operator-resolved events (resolved_at set via /admin/error_events) are
+  # excluded so triaged errors stop being re-reported week after week. A
+  # fingerprint resurfaces only if new, unresolved occurrences arrive.
   def error_events_text
-    groups = ErrorEvent
-      .where(occurred_at: @week_start..@week_end)
+    scope = ErrorEvent.where(occurred_at: @week_start..@week_end)
+    resolved_count = scope.where.not(resolved_at: nil).count
+    open_scope = scope.where(resolved_at: nil)
+
+    groups = open_scope
       .group(:fingerprint)
       .select(
         "fingerprint",
@@ -437,19 +449,25 @@ class ActivityFeed
         "MAX(occurred_at) AS last_seen",
         "MIN(occurred_at) AS first_seen",
         "MAX(source) AS source",
-        "MAX(error_class) AS error_class",
-        "BOOL_OR(resolved_at IS NOT NULL) AS any_resolved"
+        "MAX(error_class) AS error_class"
       )
       .order(Arel.sql("COUNT(*) DESC, MAX(occurred_at) DESC"))
       .limit(15)
       .to_a
-    return nil if groups.empty?
 
-    total = ErrorEvent.where(occurred_at: @week_start..@week_end).count
-    by_source = ErrorEvent.where(occurred_at: @week_start..@week_end).group(:source).count
+    excluded_note = "#{resolved_count} resolved event#{'s' unless resolved_count == 1} excluded"
+    if groups.empty?
+      return nil if resolved_count.zero?
+      return "== Application Errors ==\n  0 unresolved events (#{excluded_note} — operator marked these triaged)"
+    end
+
+    total = open_scope.count
+    by_source = open_scope.group(:source).count
     source_summary = %w[server browser job].filter_map { |s| "#{by_source[s] || 0} #{s}" }.join(" / ")
+    source_summary += "; #{excluded_note}" if resolved_count.positive?
 
     latest_events = ErrorEvent.where(id: groups.map(&:latest_id)).index_by(&:id)
+    recurred = ErrorEvent.where(fingerprint: groups.map(&:fingerprint)).where.not(resolved_at: nil).distinct.pluck(:fingerprint).to_set
 
     lines = ["== Application Errors (#{total} events: #{source_summary}) =="]
     groups.each do |g|
@@ -457,13 +475,54 @@ class ActivityFeed
       message = latest&.message.to_s.lines.first&.strip
       message = message[0, 160] + "…" if message && message.length > 160
       top_frame = latest&.backtrace.to_s.lines.find { |l| l.include?("/app/") }&.strip
-      status = g.any_resolved ? " [resolved]" : ""
+      status = recurred.include?(g.fingerprint) ? " [recurred after resolve]" : ""
       header = "  [#{g.source}] #{g.error_class} ×#{g.event_count} (last #{g.last_seen.strftime('%-m/%d %l:%M%P').strip})#{status}"
       lines << header
       lines << "    msg: #{message}" if message.present?
       lines << "    at:  #{top_frame}" if top_frame.present?
       lines << "    url: #{latest.http_method} #{latest.url}".rstrip if latest&.url.present?
       lines << "    id:  #{latest.id} (fingerprint #{g.fingerprint})" if latest
+    end
+    lines.join("\n")
+  end
+
+  # The one datum that settles deliverability questions: provider-side bounce
+  # and complaint counts. Memoized — to_text runs twice per analysis (summary
+  # + verbose) and shouldn't hit the API twice.
+  def deliverability_text
+    unless defined?(@sendgrid_stats)
+      @sendgrid_stats = SendgridStats.for_period(@week_start.to_date, (@week_end - 1.day).to_date)
+    end
+    stats = @sendgrid_stats
+
+    if stats.nil?
+      "Deliverability (SendGrid): data unavailable (API key missing or request failed)"
+    else
+      counts = [
+        "#{stats[:delivered]} delivered",
+        "#{stats[:bounces]} bounce#{'s' unless stats[:bounces] == 1}",
+        "#{stats[:blocks]} block#{'s' unless stats[:blocks] == 1}",
+        "#{stats[:spam_reports]} spam report#{'s' unless stats[:spam_reports] == 1}"
+      ]
+      "Deliverability (SendGrid, account-wide for this week): #{counts.join(', ')}"
+    end
+  end
+
+  # An explicit count (even "0 failed jobs") so the analysis never has to
+  # speculate about silent job failures it can't verify.
+  def failed_jobs_text
+    return nil unless defined?(SolidQueue::FailedExecution)
+
+    failures = SolidQueue::FailedExecution.includes(:job).where(created_at: @week_start..@week_end).order(:created_at).to_a
+    lines = ["== Failed Jobs (solid_queue_failed_executions) =="]
+    if failures.empty?
+      lines << "  0 failed jobs this week"
+    else
+      lines << "  #{failures.size} failed job#{'s' unless failures.size == 1} this week:"
+      failures.each do |failure|
+        detail = failure.error.present? ? [failure.exception_class, failure.message.to_s.lines.first&.strip].compact.join(": ") : "(no error details)"
+        lines << "  #{failure.created_at.strftime('%-m/%d %l:%M%P').strip} #{failure.job&.class_name}: #{detail}"
+      end
     end
     lines.join("\n")
   end

--- a/app/services/anomaly_detector.rb
+++ b/app/services/anomaly_detector.rb
@@ -68,6 +68,19 @@ class AnomalyDetector
 
   def build_user_message
     parts = []
+
+    probe = UptimeProbe.check
+    if probe
+      timestamp = probe[:checked_at].strftime("%-l:%M%P")
+      parts << "## Uptime Probe"
+      parts << if probe[:status]
+        "GET #{probe[:url]} responded #{probe[:status]} in #{probe[:latency_ms]}ms at #{timestamp} — the site was reachable when this report ran."
+      else
+        "GET #{probe[:url]} FAILED at #{timestamp}: #{probe[:error]}"
+      end
+      parts << ""
+    end
+
     @on_progress.call("Building feed for #{@week_id} (verbose)…")
     current_feed = ActivityFeed.new(@week_id)
     current_events = current_feed.verbose_events

--- a/app/services/sendgrid_stats.rb
+++ b/app/services/sendgrid_stats.rb
@@ -1,0 +1,55 @@
+require "net/http"
+
+# Pulls aggregate deliverability stats (bounces, blocks, spam reports) from the
+# SendGrid Stats API so the anomaly report has real data instead of guessing
+# about deliverability from open rates alone.
+#
+# Auth: prefers SENDGRID_API_KEY; falls back to SENDGRID_PASSWORD when
+# SENDGRID_USERNAME is "apikey" (modern SendGrid SMTP auth — the password *is*
+# an API key). Returns nil when no key is configured or the request fails.
+class SendgridStats
+  ENDPOINT = URI("https://api.sendgrid.com/v3/stats")
+  METRICS = %i[requests delivered bounces blocks spam_reports invalid_emails].freeze
+
+  def self.api_key
+    return ENV["SENDGRID_API_KEY"] if ENV["SENDGRID_API_KEY"].present?
+    return ENV["SENDGRID_PASSWORD"] if ENV["SENDGRID_USERNAME"] == "apikey" && ENV["SENDGRID_PASSWORD"].present?
+
+    nil
+  end
+
+  def self.for_period(start_date, end_date)
+    key = api_key
+    return nil unless key
+
+    uri = ENDPOINT.dup
+    uri.query = URI.encode_www_form(
+      start_date: start_date.to_date.iso8601,
+      end_date: [end_date.to_date, Date.current].min.iso8601,
+      aggregated_by: "day"
+    )
+
+    response = Net::HTTP.start(uri.host, uri.port, use_ssl: true, open_timeout: 5, read_timeout: 10) do |http|
+      request = Net::HTTP::Get.new(uri)
+      request["Authorization"] = "Bearer #{key}"
+      http.request(request)
+    end
+
+    unless response.is_a?(Net::HTTPSuccess)
+      Rails.logger.warn "[SendgridStats] API returned #{response.code}: #{response.body.to_s.first(200)}"
+      return nil
+    end
+
+    totals = METRICS.index_with { 0 }
+    JSON.parse(response.body).each do |day|
+      day["stats"].to_a.each do |stat|
+        metrics = stat["metrics"] || {}
+        METRICS.each { |m| totals[m] += metrics[m.to_s].to_i }
+      end
+    end
+    totals
+  rescue StandardError => e
+    Rails.logger.warn "[SendgridStats] #{e.class}: #{e.message}"
+    nil
+  end
+end

--- a/app/services/uptime_probe.rb
+++ b/app/services/uptime_probe.rb
@@ -1,0 +1,30 @@
+require "net/http"
+
+# A live "is the site up right now?" check included in the anomaly analysis
+# prompt, so the report never has to ask the operator to "verify the site was
+# accessible". Probes UPTIME_PROBE_URL (defaults to the public site in
+# production); returns nil when no URL is configured (dev/test).
+class UptimeProbe
+  def self.url
+    return ENV["UPTIME_PROBE_URL"] if ENV["UPTIME_PROBE_URL"].present?
+    return nil unless Rails.env.production?
+
+    domain = ENV["HEROKU_APP_NAME"] ? "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" : ShopConfig.shop.app_domain
+    "https://#{domain}"
+  end
+
+  def self.check(target = url)
+    return nil if target.blank?
+
+    uri = URI(target)
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https", open_timeout: 5, read_timeout: 10) do |http|
+      http.request(Net::HTTP::Get.new(uri.path.presence || "/"))
+    end
+    latency_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round
+
+    { url: target, status: response.code.to_i, latency_ms: latency_ms, checked_at: Time.current }
+  rescue StandardError => e
+    { url: target, status: nil, error: "#{e.class}: #{e.message}", checked_at: Time.current }
+  end
+end

--- a/test/controllers/admin/activity_feed_controller_test.rb
+++ b/test/controllers/admin/activity_feed_controller_test.rb
@@ -34,6 +34,40 @@ class Admin::ActivityFeedControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to '/admin/activity_feed?week_id=26w01'
   end
 
+  test "post reply creates an admin analysis reply" do
+    analysis = anomaly_analyses(:week1_analysis)
+
+    assert_difference -> { AnalysisReply.count }, 1 do
+      post '/admin/activity_feed/reply', params: { analysis_id: analysis.id, body: "Acknowledged — duplicate email finding is resolved." }
+    end
+
+    reply = AnalysisReply.last
+    assert_equal "admin", reply.source
+    assert_equal analysis, reply.anomaly_analysis
+    assert_equal users(:kyle).email, reply.author_email
+    assert_redirected_to "/admin/activity_feed?week_id=#{analysis.week_id}"
+  end
+
+  test "post reply with blank body does not create a reply" do
+    analysis = anomaly_analyses(:week1_analysis)
+
+    assert_no_difference -> { AnalysisReply.count } do
+      post '/admin/activity_feed/reply', params: { analysis_id: analysis.id, body: "   " }
+    end
+  end
+
+  test "analyses panel renders a quick reply form" do
+    analysis = anomaly_analyses(:week1_analysis)
+
+    get "/admin/activity_feed?week_id=#{analysis.week_id}"
+
+    assert_response :success
+    assert_select "form[action=?]", "/admin/activity_feed/reply" do
+      assert_select "textarea[name=body]"
+      assert_select "input[name=analysis_id][value=?]", analysis.id.to_s
+    end
+  end
+
   test "current week defaults to today and shows today marker" do
     travel_to_week_id("19w01") do
       get '/admin/activity_feed'

--- a/test/services/activity_feed_test.rb
+++ b/test/services/activity_feed_test.rb
@@ -1,9 +1,15 @@
 require "test_helper"
 
 class ActivityFeedTest < ActiveSupport::TestCase
+  include WebMock::API
+
   setup do
     @week_id = "19w01"
     @menu = menus(:week1)
+  end
+
+  teardown do
+    WebMock.reset!
   end
 
   test "summary returns an array of Events" do
@@ -423,6 +429,118 @@ class ActivityFeedTest < ActiveSupport::TestCase
 
     text = ActivityFeed.new(@week_id).to_text(verbose: true)
     assert_match(/RAPID DUPLICATE/, text, "sub-minute-gap confirmations are the real bug signal")
+  end
+
+  test "to_text notes deliverability data is unavailable without SendGrid credentials" do
+    travel_to_week_id(@week_id) do
+      Ahoy::Message.create!(mailer: "MenuMailer#weekly_menu_email", menu: @menu, user: users(:kyle), sent_at: Time.zone.now)
+    end
+
+    text = ActivityFeed.new(@week_id).to_text
+
+    assert_match(/Deliverability \(SendGrid\): data unavailable/, text)
+  end
+
+  test "to_text includes SendGrid bounce and spam counts when available" do
+    ENV["SENDGRID_API_KEY"] = "SG.test-key"
+    body = [
+      { date: "2026-01-01", stats: [{ metrics: { requests: 20, delivered: 18, bounces: 2, blocks: 1, spam_reports: 1, invalid_emails: 0 } }] }
+    ].to_json
+    stub_request(:get, "https://api.sendgrid.com/v3/stats")
+      .with(query: hash_including({}))
+      .to_return(status: 200, body: body, headers: { "Content-Type" => "application/json" })
+
+    travel_to_week_id(@week_id) do
+      Ahoy::Message.create!(mailer: "MenuMailer#weekly_menu_email", menu: @menu, user: users(:kyle), sent_at: Time.zone.now)
+    end
+
+    text = ActivityFeed.new(@week_id).to_text
+
+    assert_match(/Deliverability \(SendGrid.*\): 18 delivered, 2 bounces, 1 block, 1 spam report/, text)
+  ensure
+    ENV.delete("SENDGRID_API_KEY")
+  end
+
+  test "to_text excludes fully resolved error fingerprints" do
+    week_id = Time.zone.now.week_id
+    week_start = Time.zone.from_week_id(week_id)
+
+    ErrorEvent.create!(
+      fingerprint: "fp-resolved", source: "server", error_class: "ResolvedError",
+      message: "triaged by operator", environment: Rails.env,
+      occurred_at: week_start + 1.hour, resolved_at: Time.current
+    )
+    ErrorEvent.create!(
+      fingerprint: "fp-open", source: "server", error_class: "OpenError",
+      message: "still live", environment: Rails.env, occurred_at: week_start + 2.hours
+    )
+
+    text = ActivityFeed.new(week_id).to_text
+
+    assert_match(/OpenError/, text)
+    assert_no_match(/ResolvedError/, text)
+    assert_match(/1 resolved event excluded/, text)
+  end
+
+  test "to_text keeps fingerprints that recur after being resolved" do
+    week_id = Time.zone.now.week_id
+    week_start = Time.zone.from_week_id(week_id)
+
+    ErrorEvent.create!(
+      fingerprint: "fp-recur", source: "server", error_class: "RecurError",
+      message: "old occurrence", environment: Rails.env,
+      occurred_at: week_start + 1.hour, resolved_at: Time.current
+    )
+    ErrorEvent.create!(
+      fingerprint: "fp-recur", source: "server", error_class: "RecurError",
+      message: "new occurrence", environment: Rails.env, occurred_at: week_start + 5.hours
+    )
+
+    text = ActivityFeed.new(week_id).to_text
+
+    assert_match(/RecurError/, text)
+    assert_match(/recurred after resolve/, text)
+  end
+
+  test "to_text notes when all error events are resolved" do
+    week_id = Time.zone.now.week_id
+    week_start = Time.zone.from_week_id(week_id)
+
+    2.times do |i|
+      ErrorEvent.create!(
+        fingerprint: "fp-quiet", source: "server", error_class: "QuietError",
+        message: "handled", environment: Rails.env,
+        occurred_at: week_start + (i + 1).hours, resolved_at: Time.current
+      )
+    end
+
+    text = ActivityFeed.new(week_id).to_text
+
+    assert_no_match(/QuietError/, text)
+    assert_match(/2 resolved events excluded/, text)
+  end
+
+  test "to_text reports zero failed jobs explicitly" do
+    text = ActivityFeed.new(@week_id).to_text
+
+    assert_match(/0 failed jobs/, text)
+  end
+
+  test "to_text includes failed job details when jobs failed" do
+    travel_to_week_id(@week_id) do
+      job = SolidQueue::Job.create!(queue_name: "default", class_name: "SendWeeklyMenuJob", arguments: "{}")
+      SolidQueue::FailedExecution.create!(
+        job: job,
+        error: { exception_class: "RuntimeError", message: "boom went the bread", backtrace: [] }
+      )
+    end
+
+    text = ActivityFeed.new(@week_id).to_text
+
+    assert_match(/1 failed job/, text)
+    assert_match(/SendWeeklyMenuJob/, text)
+    assert_match(/RuntimeError/, text)
+    assert_match(/boom went the bread/, text)
   end
 
   test "verbose feed still tags reminder emails with DUPLICATE when user/pickup_day collides" do

--- a/test/services/anomaly_detector_integration_test.rb
+++ b/test/services/anomaly_detector_integration_test.rb
@@ -1,6 +1,27 @@
 require "test_helper"
 
 class AnomalyDetectorIntegrationTest < ActiveSupport::TestCase
+  include WebMock::API
+
+  test "build_user_message includes uptime probe result when configured" do
+    ENV["UPTIME_PROBE_URL"] = "https://probe.test/"
+    stub_request(:get, "https://probe.test/").to_return(status: 200, body: "ok")
+
+    message = AnomalyDetector.new("19w01").build_user_message
+
+    assert_match(/Uptime Probe/, message)
+    assert_match(/responded 200 in \d+ms/, message)
+  ensure
+    ENV.delete("UPTIME_PROBE_URL")
+    WebMock.reset!
+  end
+
+  test "build_user_message omits uptime probe section when not configured" do
+    message = AnomalyDetector.new("19w01").build_user_message
+
+    assert_no_match(/Uptime Probe/, message)
+  end
+
   test "detects anomaly when orders are missing" do
     menu = menus(:week1)
     travel_to_week_id(menu.week_id) do

--- a/test/services/sendgrid_stats_test.rb
+++ b/test/services/sendgrid_stats_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class SendgridStatsTest < ActiveSupport::TestCase
+  include WebMock::API
+
+  setup do
+    @original_env = ENV.to_h.slice("SENDGRID_API_KEY", "SENDGRID_USERNAME", "SENDGRID_PASSWORD")
+    ENV.delete("SENDGRID_API_KEY")
+    ENV.delete("SENDGRID_USERNAME")
+    ENV.delete("SENDGRID_PASSWORD")
+  end
+
+  teardown do
+    %w[SENDGRID_API_KEY SENDGRID_USERNAME SENDGRID_PASSWORD].each do |key|
+      @original_env.key?(key) ? ENV[key] = @original_env[key] : ENV.delete(key)
+    end
+    WebMock.reset!
+  end
+
+  test "returns nil when no api key is configured" do
+    assert_nil SendgridStats.for_period(Date.new(2026, 6, 7), Date.new(2026, 6, 13))
+  end
+
+  test "sums metrics across days" do
+    ENV["SENDGRID_API_KEY"] = "SG.test-key"
+    body = [
+      { date: "2026-06-07", stats: [{ metrics: { requests: 10, delivered: 9, bounces: 1, blocks: 0, spam_reports: 0, invalid_emails: 0 } }] },
+      { date: "2026-06-08", stats: [{ metrics: { requests: 5, delivered: 4, bounces: 0, blocks: 1, spam_reports: 1, invalid_emails: 0 } }] }
+    ].to_json
+    stub_request(:get, "https://api.sendgrid.com/v3/stats")
+      .with(
+        query: hash_including("start_date" => "2026-06-07", "aggregated_by" => "day"),
+        headers: { "Authorization" => "Bearer SG.test-key" }
+      )
+      .to_return(status: 200, body: body, headers: { "Content-Type" => "application/json" })
+
+    stats = SendgridStats.for_period(Date.new(2026, 6, 7), Date.new(2026, 6, 13))
+
+    assert_equal 15, stats[:requests]
+    assert_equal 13, stats[:delivered]
+    assert_equal 1, stats[:bounces]
+    assert_equal 1, stats[:blocks]
+    assert_equal 1, stats[:spam_reports]
+  end
+
+  test "falls back to SENDGRID_PASSWORD when username is apikey" do
+    ENV["SENDGRID_USERNAME"] = "apikey"
+    ENV["SENDGRID_PASSWORD"] = "SG.smtp-key"
+    stub_request(:get, "https://api.sendgrid.com/v3/stats")
+      .with(query: hash_including({}), headers: { "Authorization" => "Bearer SG.smtp-key" })
+      .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+
+    stats = SendgridStats.for_period(Date.new(2026, 6, 7), Date.new(2026, 6, 13))
+
+    assert_equal 0, stats[:bounces]
+  end
+
+  test "does not use SENDGRID_PASSWORD when username is a legacy account name" do
+    ENV["SENDGRID_USERNAME"] = "app12345@heroku.com"
+    ENV["SENDGRID_PASSWORD"] = "not-an-api-key"
+
+    assert_nil SendgridStats.for_period(Date.new(2026, 6, 7), Date.new(2026, 6, 13))
+  end
+
+  test "returns nil when the API errors" do
+    ENV["SENDGRID_API_KEY"] = "SG.test-key"
+    stub_request(:get, "https://api.sendgrid.com/v3/stats")
+      .with(query: hash_including({}))
+      .to_return(status: 403, body: { errors: [{ message: "access forbidden" }] }.to_json)
+
+    assert_nil SendgridStats.for_period(Date.new(2026, 6, 7), Date.new(2026, 6, 13))
+  end
+
+  test "clamps end_date to today so SendGrid never sees a future date" do
+    ENV["SENDGRID_API_KEY"] = "SG.test-key"
+    stub = stub_request(:get, "https://api.sendgrid.com/v3/stats")
+      .with(query: hash_including("end_date" => Date.current.iso8601))
+      .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+
+    SendgridStats.for_period(Date.current - 3, Date.current + 3)
+
+    assert_requested stub
+  end
+end

--- a/test/services/uptime_probe_test.rb
+++ b/test/services/uptime_probe_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class UptimeProbeTest < ActiveSupport::TestCase
+  include WebMock::API
+
+  setup do
+    @original = ENV["UPTIME_PROBE_URL"]
+    ENV.delete("UPTIME_PROBE_URL")
+  end
+
+  teardown do
+    @original ? ENV["UPTIME_PROBE_URL"] = @original : ENV.delete("UPTIME_PROBE_URL")
+    WebMock.reset!
+  end
+
+  test "returns nil when no probe url is configured" do
+    assert_nil UptimeProbe.check
+  end
+
+  test "reports status and latency for a successful probe" do
+    stub_request(:get, "https://example.test/").to_return(status: 200, body: "ok")
+
+    result = UptimeProbe.check("https://example.test/")
+
+    assert_equal 200, result[:status]
+    assert result[:latency_ms] >= 0
+    assert result[:checked_at].present?
+  end
+
+  test "reports the error when the site is unreachable" do
+    stub_request(:get, "https://example.test/").to_timeout
+
+    result = UptimeProbe.check("https://example.test/")
+
+    assert_nil result[:status]
+    assert_match(/timeout/i, result[:error])
+  end
+
+  test "uses UPTIME_PROBE_URL when set" do
+    ENV["UPTIME_PROBE_URL"] = "https://probe.test/"
+    stub_request(:get, "https://probe.test/").to_return(status: 200)
+
+    assert_equal 200, UptimeProbe.check[:status]
+  end
+end


### PR DESCRIPTION
Closes #336

Every false alarm in the March–June review of 103 nightly analyses traced to missing *input* data, not model error. This PR feeds the five missing signals into the analysis.

## What's new in the feed

1. **Failed Jobs section** — explicit `solid_queue_failed_executions` count, including a literal "0 failed jobs this week", so the model never speculates about silent job failures. Failures include class name, exception, and first line of the message.
2. **Deliverability line** (Email Health) — bounce / block / spam-report / delivered counts from the SendGrid Stats API. Prod needs no new config: `SENDGRID_USERNAME` is `apikey`, so `SENDGRID_PASSWORD` *is* an API key (an explicit `SENDGRID_API_KEY` takes precedence if set later). On a missing key or failed request it prints an explicit "data unavailable" note instead of erroring. Memoized per feed; end date clamped to today.
3. **Resolved-error filtering** — `error_events.resolved_at` (previously unused by the feed) now excludes operator-triaged fingerprints, with an "N resolved events excluded" note so counts stay honest. A fingerprint that recurs after being resolved comes back tagged `[recurred after resolve]`. The resolve/unresolve buttons already existed in `/admin/error_events`.
4. **Uptime Probe** — live HTTP GET of the site as the report runs ("responded 200 in 340ms at 9:21pm"), eliminating "verify the site was accessible" action items. URL: `UPTIME_PROBE_URL` env override, defaults to the public site in production, disabled in dev/test.
5. **Admin quick-reply** — each analysis card in `/admin/activity_feed` gets a reply form that creates an `AnalysisReply` (`source: admin`), which already flows into the next prompt. Closes the operator feedback loop without an email round-trip.

The system prompt (`app/prompts/anomaly_detection.txt`) now explains how to read each new section — trust the explicit zero, settle deliverability questions from the SendGrid line, don't re-flag triaged errors, don't ask the operator to check uptime.

## Notes

- If the SendGrid key turns out to lack the `stats.read` scope, the line degrades to "data unavailable" — swap in a scoped `SENDGRID_API_KEY` to fix.
- Per the issue, model stays `claude-sonnet-4-6`; no caching changes (moot at one run/day).

## Tests

- 22 new Minitest cases (feed sections, SendgridStats, UptimeProbe, admin reply action + form render), TDD'd red→green.
- Full suite: 433 Rails + 53 JS, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)