### PR TITLE
Sanitize order comments rendered in the admin panel

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -89,8 +89,12 @@ class Order < ApplicationRecord
   end
 
   def comments_html
-    if self.comments.present?
-      Menu::MARKDOWN.render(self.comments).html_safe
-    end
+    return if comments.blank?
+
+    # Comments are member-supplied free text shown in the admin panel, so the
+    # rendered markdown must be sanitized — Redcarpet's HTML renderer passes raw
+    # tags through, and sanitize also strips dangerous schemes (e.g. javascript:)
+    # from any links the parser generates.
+    ActionController::Base.helpers.sanitize(Menu::MARKDOWN.render(comments))
   end
 end

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -72,12 +72,45 @@ class OrderTest < ActiveSupport::TestCase
     day1, day2 = o.menu.pickup_days
     assert_equal 1, o.items_for_pickup(day1).count
     assert_equal 0, o.items_for_pickup(day2).count
-    
+
     o.order_items.create!(item: items(:classic), quantity: 1, pickup_day: day2)
     o.order_items.create!(item: items(:classic), quantity: 1, pickup_day: day2)
     assert_equal 2, o.items_for_pickup(day2).count
 
     o.order_items.create!(item_id: Item::PAY_IT_FORWARD_ID, quantity: 1, pickup_day: day2)
     assert_equal 2, o.items_for_pickup(day2).count
+  end
+
+  test "comments_html renders markdown formatting" do
+    o = orders(:kyle_week1)
+    o.update!(comments: "**bold** and a [link](https://example.com)")
+    html = o.comments_html
+    assert_includes html, "<strong>bold</strong>"
+    assert_includes html, 'href="https://example.com"'
+  end
+
+  test "comments_html is nil when comments are blank" do
+    assert_nil orders(:adrian_week1).comments_html
+  end
+
+  # Order comments are member-supplied free text rendered into the admin panel
+  # (app/admin/orders.rb, app/admin/dashboard.rb). They must never carry active
+  # HTML into an admin session.
+  test "comments_html strips script tags" do
+    o = orders(:kyle_week1)
+    o.update!(comments: "hi <script>alert(document.cookie)</script>")
+    refute_includes o.comments_html, "<script>"
+  end
+
+  test "comments_html strips inline event handlers" do
+    o = orders(:kyle_week1)
+    o.update!(comments: "<img src=x onerror=alert(1)>")
+    refute_includes o.comments_html, "onerror"
+  end
+
+  test "comments_html strips javascript: links" do
+    o = orders(:kyle_week1)
+    o.update!(comments: "[click me](javascript:alert(document.cookie))")
+    refute_includes o.comments_html, "javascript:"
   end
 end


### PR DESCRIPTION
## What

`Order#comments_html` renders member-supplied order comments as HTML into the ActiveAdmin **orders index** (`app/admin/orders.rb`) and the **dashboard** (`app/admin/dashboard.rb`). The shared markdown renderer (`Menu::MARKDOWN`) is a `Redcarpet::Render::HTML` with no HTML filtering, and the output was marked `html_safe` — so raw tags and `javascript:` links passed straight through into an authenticated admin session.

Because order creation is reachable without logging in, this was a **stored XSS that executes the moment an admin opens the orders list to review** — i.e. the human-moderation step is what triggers it, so it isn't something a person catches by eyeballing the order.

## Fix

Route the rendered markdown through Rails' `sanitize` before display. Formatting (bold, links, lists) is preserved; `<script>`, inline event handlers (`onerror=`), and dangerous URL schemes are stripped.

## Tests

Added `Order#comments_html` coverage: markdown formatting still renders, blank comments return nil, and script tags / inline handlers / `javascript:` links are all stripped. Full Rails suite green (416 runs, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)