### PR TITLE
Require payment to attach a guest order to an existing account

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -11,6 +11,13 @@ class OrdersController < ApplicationController
     end
 
     if (existing_user = User.find_by(email: params.fetch(:email).strip.downcase)).present?
+      # Guest checkout may only attach to an existing account for a genuinely
+      # paid marketplace order. Without this, an unauthenticated request could
+      # place a credit-spending order in any member's name just by knowing their
+      # email — draining their credits. A returning member must sign in.
+      unless paid_marketplace_order?
+        raise OrderError.new("An account with that email already exists — please sign in to place your order")
+      end
       return existing_user
     end
 
@@ -161,6 +168,14 @@ class OrdersController < ApplicationController
   end
 
   private
+
+  # A real paid marketplace order results in a Stripe charge (price > 0 with a
+  # card token), which sets stripe_charge_id and so is excluded from credit
+  # accounting. A $0 or token-less order would leave stripe_charge_id NULL and
+  # count against the member's credit balance.
+  def paid_marketplace_order?
+    params[:price].to_f > 0 && params[:token].present?
+  end
 
   def render_ordering_closed
     return render_validation_failed("ordering for this menu is closed")

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -16,7 +16,7 @@ class OrdersController < ApplicationController
       # place a credit-spending order in any member's name just by knowing their
       # email — draining their credits. A returning member must sign in.
       unless paid_marketplace_order?
-        raise OrderError.new("An account with that email already exists — please sign in to place your order")
+        raise OrderError.new("Email passed as param — Please use a link from a menu email or sign in to place your order")
       end
       return existing_user
     end

--- a/test/controllers/orders_controller_test.rb
+++ b/test/controllers/orders_controller_test.rb
@@ -122,6 +122,42 @@ class OrdersControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
   end
 
+  # Guest checkout (email param) must not let an unauthenticated request place a
+  # credit-spending order in an existing member's name — that would drain the
+  # member's credits. A returning member with an existing account must sign in.
+  test "guest email path cannot place an unpaid order for an existing member" do
+    victim = users(:ljf)
+    before_deadline do
+      refute_ordered do
+        post '/orders.json', params: order_attrs(nil).merge(email: victim.email), as: :json
+      end
+    end
+    assert_response :unprocessable_content
+  end
+
+  test "guest email path cannot place a $0 order for an existing member" do
+    victim = users(:ljf)
+    before_deadline do
+      refute_ordered do
+        post '/orders.json', params: order_attrs(nil).merge(email: victim.email, price: 0), as: :json
+      end
+    end
+    assert_response :unprocessable_content
+  end
+
+  test "new guest can still place a marketplace order by email" do
+    before_deadline do
+      assert_ordered do
+        post '/orders.json', params: order_attrs(nil).merge(
+          email: "newguest@example.com",
+          first_name: "New", last_name: "Guest", phone: "555-0000", price: 0
+        ), as: :json
+      end
+    end
+    assert_response :success
+    assert_equal "newguest@example.com", Order.last.user.email
+  end
+
   test "non-admin user cannot order from a non-current non-holiday menu" do
     sign_in users(:jess)
     non_current_menu = menus(:week3)


### PR DESCRIPTION
## What

`OrdersController#create` resolves the order's user from the `email` param **with no proof of ownership** — `User.find_by(email: …)`. The controller includes `UserHashidable`, which skips `authenticate_user!`, so an unauthenticated `POST /orders` with `email=member@example.com` placed the order in that member's name.

Because a subscription order (no Stripe charge) counts against credit balance in `_user_credits.sql.erb` (it keys on `stripe_charge_id IS NULL`), this let anyone **drain a member's credits** — and trigger confirmation emails to them — just by knowing their email. The human "review before fulfillment" step doesn't catch credit accounting.

## Fix

Guest checkout (the `email` path) may now attach to an **existing** account only for a genuine **paid marketplace order** (`price > 0` with a card `token`, which produces a Stripe charge and so is excluded from credit accounting). A returning member with an existing account is asked to sign in.

Brand-new guests are unaffected — a new email never reaches the existing-account branch — so new-guest marketplace orders (including the legitimate $0 case) keep working.

This is the scoped form of the fix we discussed ("Option C"): it targets the existing-account branch so it kills credit-drain **without** breaking the $0 new-guest marketplace flow that a blanket payment requirement would have broken. A *paying* attacker could still attach a paid order to a member's email (cosmetic, no credit loss); closing that is a possible follow-up.

## Tests

- guest email path cannot place an unpaid order for an existing member (no order created)
- guest email path cannot place a $0 order for an existing member
- new guest can still place a marketplace order by email
- existing $0 marketplace + member/hashid/admin order tests still green

Full Rails suite green (serial and parallel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)