### PR TITLE
Recurring uptime monitoring weighted by real usage patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,20 @@ To report a handled exception from a service or job, call
 `Rails.error.report(exception, handled: true, severity: :warning, context: {...})`.
 The subscriber will persist it (severity `:info` is skipped).
 
+## Uptime monitoring
+
+`UptimeCheckJob` (every 5 min via `config/recurring.yml`) probes `/menu.json` and
+the admin on a usage-weighted schedule (`UptimeSchedule`), recording to
+`uptime_checks` (90-day retention). Two consecutive failures report one
+`UptimeCheck::OutageError` to error tracking. Surfaced in `/admin/activity_feed`
+(grid column + chart line + feed text) and `/admin/uptime_checks`.
+
+**Env vars on Heroku:** `UPTIME_PROBE_URL` (optional override; defaults to the
+public site) and `UPTIME_PROBE_TOKEN` — when set, the admin probe hits the
+token-guarded `/health/admin?token=…` (server-side subchecks: menu, orders,
+error_events, queue staleness; 404 without the token) instead of plain `/admin`.
+Generate/set like `REPLY_WEBHOOK_SECRET` below.
+
 ## Heroku Memory / R14
 
 R14 is a **soft** memory warning — the dyno exceeded its 512MB quota and went to swap. On Heroku's essential tier this is expected behavior; the process keeps running. Do not treat R14 as an error or escalate it. Only R15 (hard kill, dyno terminated) is a real problem. The worker dyno routinely runs above quota in swap — this is acceptable for our workload.

--- a/app/admin/activity_feed.rb
+++ b/app/admin/activity_feed.rb
@@ -128,7 +128,10 @@ ActiveAdmin.register_page "Activity Feed" do
       item_count = menus.any? ? OrderItem.joins(:order).where(orders: { menu_id: menus.select(:id) }).count : 0
       email_count = menus.any? ? Ahoy::Message.where(menu_id: menus.select(:id)).count : 0
       visitor_count = Ahoy::Visit.where(started_at: ws..we).distinct.count(:visitor_token)
-      { week: wid, orders: order_count, items: item_count, emails: email_count, visitors: visitor_count }
+      uptime_counts = UptimeCheck.for_period(ws..we).group(:up).count
+      uptime_total = uptime_counts.values.sum
+      uptime_pct = uptime_total.positive? ? ((uptime_counts[true] || 0) * 100.0 / uptime_total).round(2) : nil
+      { week: wid, orders: order_count, items: item_count, emails: email_count, visitors: visitor_count, uptime: uptime_pct }
     end
 
     panel "Weekly Trends" do
@@ -190,6 +193,18 @@ ActiveAdmin.register_page "Activity Feed" do
                     fill: true,
                     yAxisID: 'y_emails',
                     pointRadius: 3
+                  },
+                  {
+                    label: 'Uptime %',
+                    data: #{trend_data.map { |d| d[:uptime] }.to_json},
+                    borderColor: '#352C63',
+                    borderWidth: 2,
+                    borderDash: [2, 2],
+                    tension: 0,
+                    fill: false,
+                    spanGaps: false,
+                    yAxisID: 'y_uptime',
+                    pointRadius: 3
                   }
                 ]
               },
@@ -203,6 +218,8 @@ ActiveAdmin.register_page "Activity Feed" do
                 scales: {
                   y_orders: { beginAtZero: true, position: 'left', grid: { color: 'rgba(0,0,0,0.05)' }, title: { display: true, text: 'Orders', color: '#2E7D32' } },
                   y_emails: { beginAtZero: true, position: 'right', grid: { drawOnChartArea: false }, title: { display: true, text: 'Emails / Visitors', color: '#888' } },
+                  // 90–100 window: on a 0–100 axis a dip to 99% would be invisible
+                  y_uptime: { min: 90, max: 100.5, display: false },
                   x: {
                     type: 'category',
                     grid: { display: false },
@@ -346,6 +363,15 @@ ActiveAdmin.register_page "Activity Feed" do
                                 span " #{label}", class: "cell-label"
                                 span " · #{d[:open_rate]}% opened", style: "color: #{rate_color}", class: "cell-dim", title: "Tracking pixel open-rate percent"
                               end
+                            when "uptime_summary"
+                              d = e.details
+                              color = d[:failures].to_i.zero? ? "green" : "red"
+                              next_day = (Date.parse(d[:date]) + 1).to_s
+                              a href: admin_uptime_checks_path(q: { checked_at_gteq: d[:date], checked_at_lteq: next_day }), class: "cell-link" do
+                                span "#{d[:pct]}%", class: "cell-num", style: "color: #{color}"
+                                span " up ", class: "cell-label"
+                                span "(#{d[:checks]} checks)", class: "cell-dim"
+                              end
                             when "recurring_jobs_summary"
                               span e.description, class: "cell-label"
                             else
@@ -401,6 +427,13 @@ ActiveAdmin.register_page "Activity Feed" do
                       span total_runs.to_s, class: "cell-num"
                       span " runs", class: "cell-label"
                       span " (#{incomplete} incomplete)", class: "cell-dim" if incomplete.positive?
+                    when "uptime_summary"
+                      total_checks = all_events.sum { |e| e.details[:checks].to_i }
+                      total_failures = all_events.sum { |e| e.details[:failures].to_i }
+                      pct = total_checks > 0 ? ((total_checks - total_failures).to_f / total_checks * 100).round : 0
+                      span "#{pct}%", class: "cell-num", style: "color: #{total_failures.zero? ? 'green' : 'red'}"
+                      span " up ", class: "cell-label"
+                      span "(#{total_checks} checks)", class: "cell-dim"
                     else
                       span "—", class: "cell-empty"
                     end

--- a/app/admin/uptime_checks.rb
+++ b/app/admin/uptime_checks.rb
@@ -1,0 +1,25 @@
+ActiveAdmin.register UptimeCheck do
+  menu parent: 'Advanced', label: 'Uptime', priority: 6
+  actions :index
+  config.sort_order = "checked_at_desc"
+
+  scope :all, default: true
+  scope("failures") { |scope| scope.where(up: false) }
+
+  filter :target, as: :select, collection: -> { UptimeCheck.distinct.pluck(:target).sort }
+  filter :up
+  filter :status
+  filter :checked_at
+
+  index do
+    column :checked_at
+    column :target
+    column :up do |check|
+      status_tag check.up ? "up" : "down", class: check.up ? "yes" : "no"
+    end
+    column :status
+    column("Latency") { |check| check.latency_ms ? "#{check.latency_ms}ms" : "—" }
+    column :error
+    column :url
+  end
+end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,56 @@
+# Probe-only admin health endpoint (see UptimeSchedule). Runs the reads
+# Russell's admin workflow depends on, server-side, without rendering
+# anything user-facing. Token-guarded and unlinked from any UI: a bad or
+# missing token (or no token configured) returns 404, so the route is
+# indistinguishable from a nonexistent page to scanners.
+class HealthController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  STALE_QUEUE_AGE = 15.minutes
+
+  CHECKS = {
+    # The query Russell's dashboard/pickup-list workflow starts from. Raises
+    # if Setting.menu_id dangles — which would break most of the admin.
+    menu: -> { Menu.current.present? },
+    orders: -> { Menu.current.orders.limit(1).load; true },
+    error_events: -> { ErrorEvent.maximum(:id); true },
+    # Probes run on the worker dyno, so a dead worker already shows up as
+    # missed slots. This catches the other failure mode: a worker that still
+    # heartbeats while ready jobs pile up unrun.
+    queue: -> {
+      oldest = SolidQueue::ReadyExecution.minimum(:created_at)
+      oldest.nil? || oldest > STALE_QUEUE_AGE.ago
+    }
+  }.freeze
+
+  def admin
+    return head :not_found unless token_valid?
+
+    results = run_checks
+    healthy = results.values.all?("ok")
+    render json: { status: healthy ? "ok" : "failing", checks: results },
+           status: healthy ? :ok : :service_unavailable
+  end
+
+  private
+
+  def token_valid?
+    expected = ENV["UPTIME_PROBE_TOKEN"]
+    expected.present? && ActiveSupport::SecurityUtils.secure_compare(params[:token].to_s, expected)
+  end
+
+  # Each subcheck is isolated; an exception is reported to error tracking
+  # (with the subcheck name) so the diagnosis lands in /admin/error_events,
+  # and surfaces in the response body for the uptime check record.
+  def run_checks
+    CHECKS.to_h do |name, check|
+      result = begin
+        check.call ? "ok" : "failing"
+      rescue StandardError => e
+        Rails.error.report(e, handled: true, severity: :warning, context: { health_check: name })
+        "#{e.class}: #{e.message}".first(200)
+      end
+      [name, result]
+    end
+  end
+end

--- a/app/jobs/trim_analytics_job.rb
+++ b/app/jobs/trim_analytics_job.rb
@@ -7,6 +7,7 @@ class TrimAnalyticsJob < ApplicationJob
     events_deleted = Ahoy::Event.where("time < ?", cutoff).delete_all
     visits_deleted = Ahoy::Visit.where("started_at < ?", cutoff).delete_all
     dyno_metrics_deleted = DynoMetric.where("recorded_at < ?", cutoff).delete_all
-    Rails.logger.info "[TrimAnalyticsJob] Deleted #{events_deleted} events, #{visits_deleted} visits, and #{dyno_metrics_deleted} dyno metrics older than #{cutoff.to_date}"
+    uptime_checks_deleted = UptimeCheck.where("checked_at < ?", cutoff).delete_all
+    Rails.logger.info "[TrimAnalyticsJob] Deleted #{events_deleted} events, #{visits_deleted} visits, #{dyno_metrics_deleted} dyno metrics, and #{uptime_checks_deleted} uptime checks older than #{cutoff.to_date}"
   end
 end

--- a/app/jobs/uptime_check_job.rb
+++ b/app/jobs/uptime_check_job.rb
@@ -1,0 +1,17 @@
+# Probes the site on a usage-weighted schedule. Runs every 5 minutes via
+# recurring.yml; UptimeSchedule decides which targets are actually due, so
+# most runs probe nothing or one URL. No-ops entirely when no probe URL is
+# configured (dev/test).
+class UptimeCheckJob < ApplicationJob
+  queue_as :default
+  limits_concurrency to: 1, key: "uptime_check"
+
+  def perform
+    UptimeSchedule.due_targets.each do |target|
+      probe = UptimeProbe.check(target.url)
+      next unless probe
+
+      UptimeCheck.record!(target: target.name, probe: probe).report_outage_if_needed
+    end
+  end
+end

--- a/app/models/uptime_check.rb
+++ b/app/models/uptime_check.rb
@@ -1,0 +1,63 @@
+# A recorded result of one scheduled HTTP probe of the site (see
+# UptimeSchedule for what gets probed when, UptimeCheckJob for the runner).
+class UptimeCheck < ApplicationRecord
+  # Never raised — used as the exception class for Rails.error.report so
+  # outages land in error_events (admin UI + weekly feed) without paging.
+  class OutageError < StandardError; end
+
+  UP_STATUSES = (200..399)
+
+  validates :target, :url, :checked_at, presence: true
+
+  scope :for_period, ->(range) { where(checked_at: range) }
+
+  def self.record!(target:, probe:)
+    create!(
+      target: target.to_s,
+      url: probe[:url],
+      status: probe[:status],
+      latency_ms: probe[:latency_ms],
+      error: probe[:error],
+      up: probe[:status].present? && UP_STATUSES.cover?(probe[:status]),
+      checked_at: probe[:checked_at]
+    )
+  end
+
+  # { "menu" => { checks:, up_count:, pct_up:, avg_latency_ms:, max_latency_ms:, failures: [UptimeCheck] } }
+  def self.summary_for_period(period_start, period_end)
+    for_period(period_start..period_end).order(:checked_at).group_by(&:target).transform_values do |rows|
+      up_count = rows.count(&:up)
+      latencies = rows.filter_map(&:latency_ms)
+      {
+        checks: rows.size,
+        up_count: up_count,
+        pct_up: (up_count.to_f / rows.size * 100).round(1),
+        avg_latency_ms: latencies.any? ? (latencies.sum.to_f / latencies.size).round : nil,
+        max_latency_ms: latencies.max,
+        failures: rows.reject(&:up)
+      }
+    end
+  end
+
+  # A single failed check is data, not an incident. Report once per outage,
+  # on the second consecutive failure — never again until the target recovers.
+  def report_outage_if_needed
+    return if up
+
+    prior = self.class.where(target: target).where("checked_at < ?", checked_at)
+                .order(checked_at: :desc).limit(2).to_a
+    return if prior.first.nil? || prior.first.up # first failure: wait for confirmation
+    return if prior.second && !prior.second.up   # outage already reported
+
+    Rails.error.report(
+      OutageError.new("Uptime: #{target} down 2 consecutive checks (GET #{url} → #{failure_detail})"),
+      handled: true,
+      severity: :warning,
+      context: { target: target, url: url, status: status, probe_error: error }
+    )
+  end
+
+  def failure_detail
+    status ? "HTTP #{status}" : error.to_s
+  end
+end

--- a/app/prompts/anomaly_detection.txt
+++ b/app/prompts/anomaly_detection.txt
@@ -18,6 +18,7 @@ You are reviewing the activity feed for the current week and comparing it to rec
 - The "Failed Jobs" section is the authoritative count from solid_queue_failed_executions. "0 failed jobs this week" means exactly that — never speculate about silent or unverifiable job failures when this section says zero.
 - The "Deliverability (SendGrid)" line in Email Health reports provider-side bounce, block, and spam-report counts. Use it to settle deliverability questions directly — do not recommend "check the mail provider for bounces" when this data is present. If it reads "data unavailable", say so once instead of speculating.
 - The "Uptime Probe" section (when present) is a live HTTP check made as this report ran. If it shows a 200, the site was reachable — do not ask the operator to verify site accessibility.
+- The "Uptime (scheduled probes)" section summarizes recurring HTTP checks of the member menu page and the admin panel, probed most often during the periods members and the operator actually use the site. Failures listed there were already reported to error tracking when they happened — mention sustained or repeated downtime, but do not treat a single isolated failed check as an incident (this site tolerates occasional blips). "Missed slots" means the worker did not run a scheduled check — a deploy or scheduler restart explains one or two, but a long gap can mean the whole app (including the worker that records these checks) was down: cross-reference deploy times and dyno metrics before flagging.
 
 ## Scheduled jobs
 

--- a/app/services/activity_feed.rb
+++ b/app/services/activity_feed.rb
@@ -542,16 +542,29 @@ class ActivityFeed
   # missed slots.
   def uptime_text
     summary = UptimeCheck.summary_for_period(@week_start, @week_end)
-    return nil if summary.empty?
-
     window_end = [@week_end, Time.current].min
-    lines = ["== Uptime (scheduled probes) =="]
-    summary.sort.each do |target, stats|
-      first_check = UptimeCheck.where(target: target).minimum(:checked_at)
-      window_start = [@week_start, first_check].compact.max
-      expected = UptimeSchedule.expected_checks(target, window_start..window_end)
-      missed = [expected - stats[:checks], 0].max
 
+    # Iterate every target that has EVER recorded a check before this window
+    # ends — not just targets with checks this week. A monitored target with
+    # zero checks all week is the loudest possible signal (the worker or the
+    # whole app was down) and must not silently drop out of the report.
+    first_checks = UptimeCheck.group(:target).minimum(:checked_at)
+      .select { |_target, first| first <= window_end }
+    return nil if first_checks.empty?
+
+    lines = ["== Uptime (scheduled probes) =="]
+    first_checks.sort.each do |target, first_check|
+      stats = summary[target]
+      window_start = [@week_start, first_check].max
+      expected = UptimeSchedule.expected_checks(target, window_start..window_end)
+
+      if stats.nil?
+        next if expected.zero? # nothing was due (e.g. week not started yet)
+        lines << "  #{target}: NO CHECKS RECORDED — #{expected} expected slots all missed (worker or whole app may have been down)"
+        next
+      end
+
+      missed = [expected - stats[:checks], 0].max
       parts = ["#{stats[:pct_up]}% up (#{stats[:up_count]}/#{stats[:checks]} checks)"]
       parts << "#{missed} missed slot#{'s' unless missed == 1}" if missed.positive?
       parts << "avg #{stats[:avg_latency_ms]}ms, max #{stats[:max_latency_ms]}ms" if stats[:avg_latency_ms]
@@ -561,6 +574,8 @@ class ActivityFeed
         lines << "    FAIL #{failure.checked_at.strftime('%-m/%d %l:%M%P').strip}: GET #{failure.url} → #{failure.failure_detail}"
       end
     end
+    return nil if lines.size == 1
+
     lines.join("\n")
   end
 

--- a/app/services/activity_feed.rb
+++ b/app/services/activity_feed.rb
@@ -41,6 +41,7 @@ class ActivityFeed
     all.concat(email_events(verbose: verbose))
     all.concat(recurring_job_events(verbose: verbose))
     all.concat(visit_events(verbose: verbose))
+    all.concat(uptime_events)
     all.sort_by(&:timestamp)
   end
 
@@ -99,7 +100,7 @@ class ActivityFeed
 
   # Columns shown in the daily grid — only the core metrics.
   # Admin events (menu_created, menu_copied, etc.) appear in the Admin Events panel instead.
-  GRID_COLUMNS = %w[daily_visits orders_summary credits_summary email_summary recurring_jobs_summary].freeze
+  GRID_COLUMNS = %w[daily_visits orders_summary credits_summary email_summary recurring_jobs_summary uptime_summary].freeze
 
   def grid_columns
     actions = summary.map(&:action).uniq
@@ -111,7 +112,8 @@ class ActivityFeed
     "orders_summary" => "Orders",
     "credits_summary" => "Credits",
     "email_summary" => "Emails",
-    "recurring_jobs_summary" => "Recurring Jobs"
+    "recurring_jobs_summary" => "Recurring Jobs",
+    "uptime_summary" => "Uptime"
   }.freeze
 
   def headline_metrics(lookback: 4)
@@ -233,6 +235,11 @@ class ActivityFeed
       failed_jobs = failed_jobs_text
       if failed_jobs
         lines << failed_jobs
+        lines << ""
+      end
+      uptime = uptime_text
+      if uptime
+        lines << uptime
         lines << ""
       end
     end
@@ -525,6 +532,58 @@ class ActivityFeed
       end
     end
     lines.join("\n")
+  end
+
+  # Scheduled probe results (UptimeCheckJob). Missed slots are reported
+  # because they're the inverse signal: if the whole app was down, the worker
+  # couldn't record its own failures — a gap in the data IS the outage. The
+  # expected-slot window starts at the target's first-ever check so weeks
+  # before the feature shipped (or a mid-week deploy of it) don't read as
+  # missed slots.
+  def uptime_text
+    summary = UptimeCheck.summary_for_period(@week_start, @week_end)
+    return nil if summary.empty?
+
+    window_end = [@week_end, Time.current].min
+    lines = ["== Uptime (scheduled probes) =="]
+    summary.sort.each do |target, stats|
+      first_check = UptimeCheck.where(target: target).minimum(:checked_at)
+      window_start = [@week_start, first_check].compact.max
+      expected = UptimeSchedule.expected_checks(target, window_start..window_end)
+      missed = [expected - stats[:checks], 0].max
+
+      parts = ["#{stats[:pct_up]}% up (#{stats[:up_count]}/#{stats[:checks]} checks)"]
+      parts << "#{missed} missed slot#{'s' unless missed == 1}" if missed.positive?
+      parts << "avg #{stats[:avg_latency_ms]}ms, max #{stats[:max_latency_ms]}ms" if stats[:avg_latency_ms]
+      lines << "  #{target}: #{parts.join(' — ')}"
+
+      stats[:failures].first(10).each do |failure|
+        lines << "    FAIL #{failure.checked_at.strftime('%-m/%d %l:%M%P').strip}: GET #{failure.url} → #{failure.failure_detail}"
+      end
+    end
+    lines.join("\n")
+  end
+
+  # One summary event per day (all targets combined) for the daily grid.
+  def uptime_events
+    checks = UptimeCheck.for_period(@week_start..@week_end).order(:checked_at)
+    checks.group_by { |c| c.checked_at.in_time_zone.to_date }.map do |date, rows|
+      up_count = rows.count(&:up)
+      failures = rows.size - up_count
+      pct = (up_count.to_f / rows.size * 100).round
+      description = if failures.zero?
+        "Uptime: 100% (#{rows.size} checks)"
+      else
+        "Uptime: #{pct}% (#{failures} of #{rows.size} checks failed)"
+      end
+      Event.new(
+        timestamp: date.in_time_zone,
+        category: "system",
+        action: "uptime_summary",
+        description: description,
+        details: { source: "uptime_checks", date: date.to_s, checks: rows.size, up: up_count, failures: failures, pct: pct }
+      )
+    end
   end
 
   def memory_metrics_text

--- a/app/services/uptime_probe.rb
+++ b/app/services/uptime_probe.rb
@@ -19,7 +19,9 @@ class UptimeProbe
     uri = URI(target)
     started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https", open_timeout: 5, read_timeout: 10) do |http|
-      http.request(Net::HTTP::Get.new(uri.path.presence || "/"))
+      # request_uri keeps the query string — a configured probe URL like
+      # /health?token=... must be requested verbatim (PR #337 review).
+      http.request(Net::HTTP::Get.new(uri.request_uri))
     end
     latency_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round
 

--- a/app/services/uptime_schedule.rb
+++ b/app/services/uptime_schedule.rb
@@ -28,8 +28,19 @@ class UptimeSchedule
 
     [
       Target.new(name: "menu", url: URI.join(base, "/menu.json").to_s),
-      Target.new(name: "admin", url: URI.join(base, "/admin").to_s)
+      Target.new(name: "admin", url: admin_url(base))
     ]
+  end
+
+  # Prefers the token-guarded /health/admin endpoint, which exercises the
+  # admin's real DB reads server-side (see HealthController). Falls back to
+  # the public /admin redirect when no token is configured so monitoring
+  # degrades instead of disappearing.
+  def self.admin_url(base)
+    token = ENV["UPTIME_PROBE_TOKEN"]
+    return URI.join(base, "/admin").to_s if token.blank?
+
+    URI.join(base, "/health/admin?token=#{CGI.escape(token)}").to_s
   end
 
   def self.due_targets(time = Time.current)

--- a/app/services/uptime_schedule.rb
+++ b/app/services/uptime_schedule.rb
@@ -1,0 +1,85 @@
+# Decides which uptime targets are due at a given moment. Cadences are
+# weighted by real usage (180 days of Ahoy visits + orders, see
+# docs/superpowers/specs/2026-06-11-uptime-monitoring.md):
+#
+#   menu  (/menu.json — anonymous, exercises Rails + Postgres + serialization)
+#     Wed 5–10pm ET   every 5 min   weekly menu email lands Wed ~6pm; that
+#                                   window carries ~30% of all orders
+#     daily 7am–11pm  every 15 min  general member traffic
+#     overnight       hourly        heartbeat only — site is near-dead
+#
+#   admin (/admin — 302 to sign-in proves routing/middleware/session stack)
+#     Wed 4–10pm ET        every 15 min   menu gets posted Wednesday evening
+#     Thu–Sat 6am–7pm ET   every 15 min   Russell's bakery-day admin hours
+#     otherwise            not probed     menu probe already covers "app up"
+#
+# UptimeCheckJob runs every 5 minutes; times round to the nearest 5-minute
+# slot so queue latency can't skip a cadence boundary.
+class UptimeSchedule
+  TIME_ZONE = "America/New_York"
+  SLOT_MINUTES = 5
+  WEDNESDAY = 3
+
+  Target = Struct.new(:name, :url, keyword_init: true)
+
+  def self.targets
+    base = UptimeProbe.url
+    return [] if base.blank?
+
+    [
+      Target.new(name: "menu", url: URI.join(base, "/menu.json").to_s),
+      Target.new(name: "admin", url: URI.join(base, "/admin").to_s)
+    ]
+  end
+
+  def self.due_targets(time = Time.current)
+    targets.select { |target| due?(target.name, time) }
+  end
+
+  def self.due?(name, time)
+    slot = slot_for(time)
+    cadence = cadence_minutes(name, slot)
+    return false unless cadence
+
+    (slot.hour * 60 + slot.min) % cadence == 0
+  end
+
+  # Number of slots in range where the target was due. The activity feed
+  # compares this to actual checks: missed slots mean the worker (or whole
+  # app) was down, or a deploy was in flight — a signal of its own, since a
+  # dead app can't record its own downtime.
+  def self.expected_checks(name, range)
+    slot = slot_for(range.begin)
+    slot += SLOT_MINUTES.minutes if slot < range.begin
+
+    count = 0
+    while slot <= range.end
+      count += 1 if due?(name, slot)
+      slot += SLOT_MINUTES.minutes
+    end
+    count
+  end
+
+  def self.slot_for(time)
+    local = time.in_time_zone(TIME_ZONE)
+    seconds_into_hour = local.min * 60 + local.sec
+    slot_seconds = ((seconds_into_hour + (SLOT_MINUTES * 60 / 2)) / (SLOT_MINUTES * 60)) * (SLOT_MINUTES * 60)
+    local.change(min: 0, sec: 0) + slot_seconds
+  end
+
+  def self.cadence_minutes(name, slot)
+    hour = slot.hour
+    case name.to_s
+    when "menu"
+      return 5 if slot.wday == WEDNESDAY && hour.between?(17, 21)
+      return 15 if hour.between?(7, 22)
+
+      60
+    when "admin"
+      return 15 if slot.wday == WEDNESDAY && hour.between?(16, 21)
+      return 15 if slot.wday.between?(4, 6) && hour.between?(6, 18)
+
+      nil
+    end
+  end
+end

--- a/bin/screenshot
+++ b/bin/screenshot
@@ -35,7 +35,9 @@ if (!url) {
   process.exit(1);
 }
 
-const BASE_URL = "http://localhost:3000";
+// Override when the server runs elsewhere (e.g. a worktree on another port);
+// --admin logs in via BASE_URL, so it must point at the server under test.
+const BASE_URL = process.env.SCREENSHOT_BASE_URL || "http://localhost:3000";
 const fullUrl = url.startsWith("/") ? `${BASE_URL}${url}` : url;
 
 // Auto-generate filename

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -34,6 +34,12 @@ production: &default
     class: CaptureDynoMetricsJob
     schedule: "3,33 * * * *"
 
+  # Enqueues every 5 minutes; UptimeSchedule decides which targets (menu/admin)
+  # are actually due at each slot, so most runs probe one URL or nothing.
+  uptime_check:
+    class: UptimeCheckJob
+    schedule: every 5 minutes
+
   capture_db_backup:
     class: CaptureDbBackupJob
     schedule: every Sunday at 3:07am America/New_York

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
   # get the menu for the week
   get "/menu", to: "menus#show", as: :current_menu
 
+  # token-guarded uptime probe target (404s unless UPTIME_PROBE_TOKEN matches)
+  get "/health/admin", to: "health#admin"
+
   # create/update order for a menu
   resources :orders, only: [:create, :update]
 

--- a/db/migrate/20260611120000_create_uptime_checks.rb
+++ b/db/migrate/20260611120000_create_uptime_checks.rb
@@ -1,0 +1,17 @@
+class CreateUptimeChecks < ActiveRecord::Migration[7.2]
+  def change
+    create_table :uptime_checks do |t|
+      t.string :target, null: false
+      t.string :url, null: false
+      t.integer :status
+      t.integer :latency_ms
+      t.string :error
+      t.boolean :up, null: false, default: false
+      t.datetime :checked_at, null: false
+
+      t.timestamps
+
+      t.index [:target, :checked_at]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_11_162604) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_11_120000) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -222,17 +222,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_11_162604) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["creator_id"], name: "index_blazer_queries_on_creator_id"
-  end
-
-  create_table "contact_messages", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "email", null: false
-    t.string "phone"
-    t.text "message", null: false
-    t.string "ip"
-    t.string "user_agent"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "credit_bundles", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_06_202929) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_11_162604) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -222,6 +222,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_06_202929) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["creator_id"], name: "index_blazer_queries_on_creator_id"
+  end
+
+  create_table "contact_messages", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "phone"
+    t.text "message", null: false
+    t.string "ip"
+    t.string "user_agent"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "credit_bundles", force: :cascade do |t|
@@ -527,6 +538,19 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_06_202929) do
     t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
     t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
+  create_table "uptime_checks", force: :cascade do |t|
+    t.string "target", null: false
+    t.string "url", null: false
+    t.integer "status"
+    t.integer "latency_ms"
+    t.string "error"
+    t.boolean "up", default: false, null: false
+    t.datetime "checked_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["target", "checked_at"], name: "index_uptime_checks_on_target_and_checked_at"
   end
 
   create_table "users", force: :cascade do |t|

--- a/docs/superpowers/specs/2026-06-11-uptime-monitoring.md
+++ b/docs/superpowers/specs/2026-06-11-uptime-monitoring.md
@@ -1,0 +1,101 @@
+# Uptime Monitoring — design spec (2026-06-11)
+
+## Goal
+
+Measure site uptime continuously, weighted toward the periods that actually matter,
+and detect & track outages without overreacting. The site is used sporadically;
+occasional downtime is acceptable — we want *visibility*, not paging.
+
+Extends the one-shot `UptimeProbe` added in PR #337 (which runs once, live, inside
+the nightly anomaly report) into a recurring, recorded check.
+
+## Real usage patterns (180 days of Ahoy visits + orders, prod, hours in ET)
+
+- **Wednesday evening is the event of the week.** The weekly menu email lands
+  Wed ~6pm: 325 visits and 80 orders in the Wed 6pm hour alone; the surge runs
+  5pm–10pm. Wednesday carries ~30% of all orders (366 of 1,219).
+- **General traffic** runs ~7am–11pm daily; overnight (11pm–6am) is near-dead.
+- **Russell's admin usage** (`users.id=2`, from Ahoy visits joined to admin users
+  + `activity_events`): mostly Thu–Sat daytime (Sat 7–8am, Thu/Fri late morning,
+  Fri 5–6pm), plus Wednesday evening when the menu goes out.
+
+## Probe targets (verified against prod)
+
+| Target | URL | Expectation | Why |
+|--------|-----|-------------|-----|
+| `menu` | `{base}/menu.json` | 200 | Anonymous; exercises Rails + Postgres + menu serialization — what a member hitting the menu actually needs. |
+| `admin` | `{base}/admin` | 302 → `/users/sign_in` | Proves routing/middleware/session stack without storing credentials. |
+
+"Up" = HTTP status 200–399. `{base}` comes from `UptimeProbe.url`
+(`UPTIME_PROBE_URL` override; defaults to the public site in production; nil in
+dev/test → the job no-ops).
+
+## Check schedule (all times ET)
+
+One Solid Queue recurring job (`UptimeCheckJob`, every 5 minutes). A pure policy
+class `UptimeSchedule` decides which targets are due for the current 5-minute
+slot (job runs round to the nearest slot, so queue latency can't skip a slot):
+
+- **menu**
+  - Wed 5pm–10pm (menu-email surge): every 5 min
+  - Daily 7am–11pm: every 15 min
+  - Overnight: hourly
+- **admin** (Russell's windows only)
+  - Wed 4pm–10pm and Thu–Sat 6am–7pm: every 15 min
+  - Otherwise: not probed (the menu probe already covers "app is up")
+
+≈ 175 menu + ~70 admin checks/week — trivial load, fine-grained where it counts.
+
+## Data model
+
+`uptime_checks`: `target` (string, NOT NULL), `url`, `status` (int, nullable),
+`latency_ms` (int), `error` (string), `up` (boolean NOT NULL), `checked_at`
+(datetime NOT NULL). Index on `[target, checked_at]`.
+
+Retention: `TrimAnalyticsJob` deletes rows older than 90 days (same cutoff as
+Ahoy data).
+
+## Outage detection (deliberately calm)
+
+A single failed check is data, not an incident (no retries — a blip recorded
+next to a success 5 minutes later reads correctly). On the **second consecutive
+failure** for a target, report once via
+`Rails.error.report(UptimeCheck::OutageError, handled: true, severity: :warning)`
+— that lands in `error_events`, so it shows up in `/admin/error_events` and the
+weekly feed without paging anyone. No re-report until the target recovers.
+
+**Self-monitoring gap:** if the whole app is down, the worker can't record
+"down" either. Missing checks are themselves the signal: the feed compares
+actual checks against the expected slot count and reports "N missed slots".
+
+## Surfacing
+
+1. **Activity feed text** (feeds the nightly anomaly prompt): an `== Uptime ==`
+   header section per target — `% up`, checks vs expected slots, avg/max latency,
+   and a line per failure. Omitted entirely for weeks with no data.
+2. **Daily grid**: new "Uptime" column (daily `uptime_summary` events: % up,
+   check count, failure count), green/red like the email open-rate cells.
+3. **Weekly trends chart**: "Uptime %" dataset on its own 90–100 y-axis (a dip
+   from 100 to 99 must be visible; on a 0–100 axis it wouldn't be).
+4. **`/admin/uptime_checks`**: read-only ActiveAdmin index with filters, for
+   drilling into raw checks.
+5. **Prompt** (`anomaly_detection.txt`): explain the Uptime section — failures
+   are already counted; missed slots may mean worker downtime or a deploy;
+   never ask the operator to "verify the site was accessible".
+
+`UptimeCheckJob` is intentionally **not** added to
+`ActivityFeed::RECURRING_JOB_LABELS` — at ~250 runs/week it would drown the
+recurring-jobs summary, and uptime has its own section. Failed job executions
+still surface through the existing Failed Jobs section.
+
+## PR #337 review feedback addressed
+
+Codex P2: `UptimeProbe.check` built the request from `uri.path` only, silently
+dropping the query string of a configured `UPTIME_PROBE_URL`
+(e.g. `/health?token=...`). Fix: request the full URI.
+
+## Out of scope
+
+External monitoring (the self-probe gap is acknowledged and partially covered
+by missed-slot reporting), paging/alerting, authenticated admin probes,
+status-page UI.

--- a/docs/superpowers/specs/2026-06-11-uptime-monitoring.md
+++ b/docs/superpowers/specs/2026-06-11-uptime-monitoring.md
@@ -24,11 +24,13 @@ the nightly anomaly report) into a recurring, recorded check.
 | Target | URL | Expectation | Why |
 |--------|-----|-------------|-----|
 | `menu` | `{base}/menu.json` | 200 | Anonymous; exercises Rails + Postgres + menu serialization — what a member hitting the menu actually needs. |
-| `admin` | `{base}/admin` | 302 → `/users/sign_in` | Proves routing/middleware/session stack without storing credentials. |
+| `admin` | `{base}/health/admin?token=…` | 200 | Token-guarded probe-only endpoint (`HealthController`) that runs the admin's real reads server-side: current menu loads, orders readable, error_events readable, ready-job queue not stale. 503 names the failing subcheck; bad/missing token → 404. Falls back to `{base}/admin` (302 → sign-in) when `UPTIME_PROBE_TOKEN` is unset. |
 
 "Up" = HTTP status 200–399. `{base}` comes from `UptimeProbe.url`
 (`UPTIME_PROBE_URL` override; defaults to the public site in production; nil in
-dev/test → the job no-ops).
+dev/test → the job no-ops). An authenticated "log in as a real admin" probe was
+considered and rejected: it needs stored credentials or a prod auth-bypass
+route — a real attack surface — and a brittle sign-in dance in Net::HTTP.
 
 ## Check schedule (all times ET)
 

--- a/test/controllers/admin/activity_feed_controller_test.rb
+++ b/test/controllers/admin/activity_feed_controller_test.rb
@@ -21,6 +21,18 @@ class Admin::ActivityFeedControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "get index renders the uptime grid column and chart dataset when checks exist" do
+    UptimeCheck.create!(target: "menu", url: "https://probe.test/menu.json", status: 200, latency_ms: 120, up: true, checked_at: Time.current)
+    UptimeCheck.create!(target: "menu", url: "https://probe.test/menu.json", status: 503, latency_ms: 40, up: false, checked_at: 10.minutes.ago)
+
+    get '/admin/activity_feed'
+
+    assert_response :success
+    assert_select 'th', text: 'Uptime'
+    assert_match 'Uptime %', @response.body # weekly trends chart dataset
+    assert_match admin_uptime_checks_path, @response.body
+  end
+
   test "get prompt_preview" do
     get '/admin/activity_feed/prompt_preview?week_id=26w01'
     assert_response :success

--- a/test/controllers/admin/uptime_checks_controller_test.rb
+++ b/test/controllers/admin/uptime_checks_controller_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class Admin::UptimeChecksControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    sign_in users(:kyle)
+  end
+
+  test "get index" do
+    UptimeCheck.create!(target: "menu", url: "https://probe.test/menu.json", status: 200, latency_ms: 120, up: true, checked_at: 1.hour.ago)
+    UptimeCheck.create!(target: "menu", url: "https://probe.test/menu.json", status: 503, latency_ms: 40, up: false, checked_at: 30.minutes.ago)
+
+    get '/admin/uptime_checks'
+
+    assert_response :success
+    assert_match "120ms", @response.body
+    assert_match "503", @response.body
+  end
+
+  test "uptime grid cell links to checks filtered by day" do
+    menus(:week1).make_current!
+    get '/admin/uptime_checks', params: { q: { checked_at_gteq: Date.yesterday.to_s, checked_at_lteq: Date.today.to_s } }
+    assert_response :success
+  end
+end

--- a/test/controllers/health_controller_test.rb
+++ b/test/controllers/health_controller_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+require "minitest/mock"
+
+class HealthControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @original = ENV["UPTIME_PROBE_TOKEN"]
+    ENV["UPTIME_PROBE_TOKEN"] = "probe-secret"
+    menus(:week1).make_current!
+  end
+
+  teardown do
+    @original ? ENV["UPTIME_PROBE_TOKEN"] = @original : ENV.delete("UPTIME_PROBE_TOKEN")
+  end
+
+  test "404 without a token, with a wrong token, and when no token is configured" do
+    get "/health/admin"
+    assert_response :not_found
+
+    get "/health/admin", params: { token: "wrong" }
+    assert_response :not_found
+
+    ENV.delete("UPTIME_PROBE_TOKEN")
+    get "/health/admin", params: { token: "probe-secret" }
+    assert_response :not_found
+  end
+
+  test "200 with all subchecks ok when the admin's reads work" do
+    get "/health/admin", params: { token: "probe-secret" }
+
+    assert_response :success
+    body = JSON.parse(@response.body)
+    assert_equal "ok", body["status"]
+    # olive_branch camelizes response keys app-wide
+    assert_equal %w[menu orders errorEvents queue], body["checks"].keys
+    assert body["checks"].values.all?("ok"), body["checks"].inspect
+  end
+
+  test "503 with the failing subcheck named when a dependency breaks" do
+    Setting.menu_id = 999_999 # dangling — Menu.current raises
+
+    # RecordNotFound is in ErrorEvent::IGNORED_SERVER_EXCEPTIONS, so no
+    # ErrorEvent here — the diagnosis travels in the response body, and the
+    # 503 itself records the uptime check as down (outage flow handles it).
+    assert_no_difference "ErrorEvent.count" do
+      get "/health/admin", params: { token: "probe-secret" }
+    end
+
+    assert_response :service_unavailable
+    body = JSON.parse(@response.body)
+    assert_equal "failing", body["status"]
+    assert_match(/RecordNotFound/, body["checks"]["menu"])
+    assert_equal "ok", body["checks"]["errorEvents"]
+  end
+
+  test "503 when ready jobs have been sitting unrun past the stale threshold" do
+    SolidQueue::ReadyExecution.stub :minimum, 20.minutes.ago do
+      get "/health/admin", params: { token: "probe-secret" }
+    end
+
+    assert_response :service_unavailable
+    assert_equal "failing", JSON.parse(@response.body)["checks"]["queue"]
+  end
+end

--- a/test/jobs/recurring_schedule_test.rb
+++ b/test/jobs/recurring_schedule_test.rb
@@ -22,6 +22,7 @@ class RecurringScheduleTest < ActiveSupport::TestCase
       analyze_anomalies
       capture_dyno_metrics
       capture_db_backup
+      uptime_check
     ]
 
     expected_jobs.each do |job|
@@ -50,10 +51,16 @@ class RecurringScheduleTest < ActiveSupport::TestCase
     end
   end
 
+  # UptimeCheckJob runs ~100×/day — labeling it would drown the recurring-jobs
+  # summary, and uptime has its own "== Uptime ==" feed section (missed slots
+  # are reported there, so the job can't silently disappear).
+  FEED_LABEL_EXEMPT = %w[UptimeCheckJob].freeze
+
   test "every recurring job class is labeled in the activity feed" do
     @production.each do |name, config|
       klass = config["class"]
       next unless klass
+      next if FEED_LABEL_EXEMPT.include?(klass)
       assert ActivityFeed::RECURRING_JOB_LABELS.key?(klass),
         "#{name} (#{klass}) is missing from ActivityFeed::RECURRING_JOB_LABELS — " \
         "the activity feed filters to labeled classes, so this job would be invisible " \

--- a/test/jobs/trim_analytics_job_test.rb
+++ b/test/jobs/trim_analytics_job_test.rb
@@ -17,6 +17,16 @@ class TrimAnalyticsJobTest < ActiveJob::TestCase
     assert_equal 1, Ahoy::Event.where(name: "new_event").count, "recent event should be preserved"
   end
 
+  test "trims uptime checks older than 90 days" do
+    old = UptimeCheck.create!(target: "menu", url: "https://probe.test/menu.json", status: 200, up: true, checked_at: 91.days.ago)
+    recent = UptimeCheck.create!(target: "menu", url: "https://probe.test/menu.json", status: 200, up: true, checked_at: 1.day.ago)
+
+    TrimAnalyticsJob.perform_now
+
+    assert_not UptimeCheck.exists?(old.id), "old uptime check should be deleted"
+    assert UptimeCheck.exists?(recent.id), "recent uptime check should be preserved"
+  end
+
   test "trims dyno metrics older than 90 days" do
     old = DynoMetric.create!(recorded_at: 91.days.ago, dyno: "web.1", memory_total: 300, memory_rss: 280, memory_swap: 0, memory_quota: 512)
     recent = DynoMetric.create!(recorded_at: 1.day.ago, dyno: "web.1", memory_total: 300, memory_rss: 280, memory_swap: 0, memory_quota: 512)

--- a/test/jobs/uptime_check_job_test.rb
+++ b/test/jobs/uptime_check_job_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class UptimeCheckJobTest < ActiveJob::TestCase
+  include WebMock::API
+
+  setup do
+    @original = ENV["UPTIME_PROBE_URL"]
+    ENV["UPTIME_PROBE_URL"] = "https://probe.test"
+  end
+
+  teardown do
+    @original ? ENV["UPTIME_PROBE_URL"] = @original : ENV.delete("UPTIME_PROBE_URL")
+    WebMock.reset!
+  end
+
+  test "probes all due targets and records checks" do
+    stub_request(:get, "https://probe.test/menu.json").to_return(status: 200)
+    stub_request(:get, "https://probe.test/admin").to_return(status: 302)
+
+    travel_to Time.zone.parse("2026-06-10 18:00") do # Wednesday 6pm ET: both due
+      UptimeCheckJob.perform_now
+    end
+
+    assert_equal 2, UptimeCheck.count
+    menu = UptimeCheck.find_by(target: "menu")
+    assert menu.up
+    assert_equal 200, menu.status
+    assert UptimeCheck.find_by(target: "admin").up
+  end
+
+  test "probes only the targets due at the current slot" do
+    stub_request(:get, "https://probe.test/menu.json").to_return(status: 200)
+
+    travel_to Time.zone.parse("2026-06-10 18:05") do # Wed 6:05pm: menu only
+      UptimeCheckJob.perform_now
+    end
+
+    assert_equal %w[menu], UptimeCheck.pluck(:target)
+  end
+
+  test "records a down check when the probe fails" do
+    stub_request(:get, "https://probe.test/menu.json").to_timeout
+
+    travel_to Time.zone.parse("2026-06-11 10:15") do # Thu: menu due, admin due
+      stub_request(:get, "https://probe.test/admin").to_return(status: 302)
+      UptimeCheckJob.perform_now
+    end
+
+    menu = UptimeCheck.find_by(target: "menu")
+    assert_not menu.up
+    assert_nil menu.status
+    assert_match(/timeout/i, menu.error)
+  end
+
+  test "no-ops when no probe url is configured" do
+    ENV.delete("UPTIME_PROBE_URL")
+
+    travel_to Time.zone.parse("2026-06-10 18:00") do
+      UptimeCheckJob.perform_now
+    end
+
+    assert_equal 0, UptimeCheck.count
+  end
+end

--- a/test/models/uptime_check_test.rb
+++ b/test/models/uptime_check_test.rb
@@ -1,0 +1,105 @@
+require "test_helper"
+
+class UptimeCheckTest < ActiveSupport::TestCase
+  def probe_result(status: 200, latency_ms: 120, error: nil, checked_at: Time.current)
+    { url: "https://probe.test/menu.json", status: status, latency_ms: latency_ms, error: error, checked_at: checked_at }
+  end
+
+  def record_check(target: "menu", **probe_overrides)
+    UptimeCheck.record!(target: target, probe: probe_result(**probe_overrides))
+  end
+
+  test "record! maps probe fields and computes up for 2xx/3xx" do
+    check = record_check(status: 200)
+    assert check.up
+    assert_equal 200, check.status
+    assert_equal 120, check.latency_ms
+
+    assert record_check(status: 302).up
+    assert_not record_check(status: 503).up
+    assert_not record_check(status: nil, latency_ms: nil, error: "Timeout::Error: timed out").up
+  end
+
+  test "summary_for_period aggregates per target" do
+    record_check(checked_at: 2.hours.ago, latency_ms: 100)
+    record_check(checked_at: 1.hour.ago, latency_ms: 300)
+    record_check(checked_at: 30.minutes.ago, status: 503, latency_ms: 50)
+    record_check(target: "admin", checked_at: 1.hour.ago, status: 302)
+
+    summary = UptimeCheck.summary_for_period(1.day.ago, Time.current)
+
+    menu = summary["menu"]
+    assert_equal 3, menu[:checks]
+    assert_equal 2, menu[:up_count]
+    assert_equal 66.7, menu[:pct_up]
+    assert_equal 150, menu[:avg_latency_ms]
+    assert_equal 300, menu[:max_latency_ms]
+    assert_equal [503], menu[:failures].map(&:status)
+
+    assert_equal 100.0, summary["admin"][:pct_up]
+  end
+
+  test "a single failure does not report an outage" do
+    record_check(checked_at: 10.minutes.ago)
+    check = record_check(status: 503, checked_at: 5.minutes.ago)
+
+    assert_no_difference "ErrorEvent.count" do
+      check.report_outage_if_needed
+    end
+  end
+
+  test "the second consecutive failure reports one outage to error tracking" do
+    record_check(checked_at: 15.minutes.ago)
+    record_check(status: 503, checked_at: 10.minutes.ago)
+    check = record_check(status: nil, latency_ms: nil, error: "Errno::ECONNREFUSED: connection refused", checked_at: 5.minutes.ago)
+
+    assert_difference "ErrorEvent.count", 1 do
+      check.report_outage_if_needed
+    end
+
+    event = ErrorEvent.order(:id).last
+    assert_equal "UptimeCheck::OutageError", event.error_class
+    assert_match(/menu down 2 consecutive checks/, event.message)
+    assert_match(/connection refused/, event.message)
+  end
+
+  test "an ongoing outage is not re-reported on later failures" do
+    record_check(status: 503, checked_at: 15.minutes.ago)
+    record_check(status: 503, checked_at: 10.minutes.ago)
+    check = record_check(status: 503, checked_at: 5.minutes.ago)
+
+    assert_no_difference "ErrorEvent.count" do
+      check.report_outage_if_needed
+    end
+  end
+
+  test "a new outage after recovery reports again" do
+    record_check(status: 503, checked_at: 40.minutes.ago)
+    record_check(status: 503, checked_at: 35.minutes.ago)
+    record_check(status: 200, checked_at: 30.minutes.ago)
+    record_check(status: 503, checked_at: 10.minutes.ago)
+    check = record_check(status: 503, checked_at: 5.minutes.ago)
+
+    assert_difference "ErrorEvent.count", 1 do
+      check.report_outage_if_needed
+    end
+  end
+
+  test "successful checks never report" do
+    record_check(status: 503, checked_at: 10.minutes.ago)
+    check = record_check(status: 200, checked_at: 5.minutes.ago)
+
+    assert_no_difference "ErrorEvent.count" do
+      check.report_outage_if_needed
+    end
+  end
+
+  test "outage streaks are tracked per target" do
+    record_check(target: "menu", status: 503, checked_at: 10.minutes.ago)
+    check = record_check(target: "admin", status: 503, checked_at: 5.minutes.ago)
+
+    assert_no_difference "ErrorEvent.count" do
+      check.report_outage_if_needed
+    end
+  end
+end

--- a/test/services/activity_feed_test.rb
+++ b/test/services/activity_feed_test.rb
@@ -554,4 +554,45 @@ class ActivityFeedTest < ActiveSupport::TestCase
     text = ActivityFeed.new(@week_id).to_text(verbose: true)
     assert_match(/DUPLICATE — 2x/, text, "reminder duplicates must still be flagged")
   end
+
+  test "to_text includes an uptime section with per-target stats and failures" do
+    week_start = Time.zone.from_week_id(@week_id)
+    UptimeCheck.create!(target: "menu", url: "https://probe.test/menu.json", status: 200, latency_ms: 100, up: true, checked_at: week_start + 1.day)
+    UptimeCheck.create!(target: "menu", url: "https://probe.test/menu.json", status: 503, latency_ms: 50, up: false, checked_at: week_start + 1.day + 15.minutes)
+    UptimeCheck.create!(target: "admin", url: "https://probe.test/admin", status: 302, latency_ms: 80, up: true, checked_at: week_start + 1.day)
+
+    text = ActivityFeed.new(@week_id).to_text
+
+    assert_includes text, "== Uptime (scheduled probes) =="
+    assert_includes text, "menu: 50.0% up (1/2 checks)"
+    assert_includes text, "admin: 100.0% up (1/1 checks)"
+    assert_match(/FAIL .* GET https:\/\/probe\.test\/menu\.json → HTTP 503/, text)
+    assert_match(/missed slot/, text, "sparse checks in a past week should surface missed slots")
+  end
+
+  test "to_text omits the uptime section when there are no checks" do
+    assert_not_includes ActivityFeed.new(@week_id).to_text, "== Uptime"
+  end
+
+  test "uptime checks roll up into one daily grid event per day" do
+    week_start = Time.zone.from_week_id(@week_id)
+    UptimeCheck.create!(target: "menu", url: "https://probe.test/menu.json", status: 200, latency_ms: 100, up: true, checked_at: week_start + 1.day + 9.hours)
+    UptimeCheck.create!(target: "admin", url: "https://probe.test/admin", status: 302, latency_ms: 80, up: true, checked_at: week_start + 1.day + 10.hours)
+    UptimeCheck.create!(target: "menu", url: "https://probe.test/menu.json", status: 500, latency_ms: 60, up: false, checked_at: week_start + 2.days + 9.hours)
+
+    feed = ActivityFeed.new(@week_id)
+    events = feed.summary.select { |e| e.action == "uptime_summary" }
+
+    assert_equal 2, events.size
+    assert_includes feed.grid_columns, "uptime_summary"
+
+    day_one = events.find { |e| e.details[:checks] == 2 }
+    assert_equal "system", day_one.category
+    assert_equal 100, day_one.details[:pct]
+    assert_equal "Uptime: 100% (2 checks)", day_one.description
+
+    day_two = events.find { |e| e.details[:checks] == 1 }
+    assert_equal 0, day_two.details[:pct]
+    assert_equal 1, day_two.details[:failures]
+  end
 end

--- a/test/services/activity_feed_test.rb
+++ b/test/services/activity_feed_test.rb
@@ -574,6 +574,25 @@ class ActivityFeedTest < ActiveSupport::TestCase
     assert_not_includes ActivityFeed.new(@week_id).to_text, "== Uptime"
   end
 
+  test "to_text omits the uptime section for weeks before monitoring existed" do
+    week_start = Time.zone.from_week_id(@week_id)
+    UptimeCheck.create!(target: "menu", url: "https://probe.test/menu.json", status: 200, latency_ms: 100, up: true, checked_at: week_start + 3.weeks)
+
+    assert_not_includes ActivityFeed.new(@week_id).to_text, "== Uptime"
+  end
+
+  test "to_text flags a monitored target that recorded zero checks all week" do
+    week_start = Time.zone.from_week_id(@week_id)
+    # admin was monitored before this week, then went completely silent
+    UptimeCheck.create!(target: "admin", url: "https://probe.test/admin", status: 302, latency_ms: 80, up: true, checked_at: week_start - 3.days)
+    UptimeCheck.create!(target: "menu", url: "https://probe.test/menu.json", status: 200, latency_ms: 100, up: true, checked_at: week_start + 1.day)
+
+    text = ActivityFeed.new(@week_id).to_text
+
+    assert_match(/admin: NO CHECKS RECORDED — \d+ expected slots all missed/, text)
+    assert_includes text, "menu: 100.0% up (1/1 checks)"
+  end
+
   test "uptime checks roll up into one daily grid event per day" do
     week_start = Time.zone.from_week_id(@week_id)
     UptimeCheck.create!(target: "menu", url: "https://probe.test/menu.json", status: 200, latency_ms: 100, up: true, checked_at: week_start + 1.day + 9.hours)

--- a/test/services/uptime_probe_test.rb
+++ b/test/services/uptime_probe_test.rb
@@ -36,6 +36,15 @@ class UptimeProbeTest < ActiveSupport::TestCase
     assert_match(/timeout/i, result[:error])
   end
 
+  test "preserves the query string of a configured probe url" do
+    stub_request(:get, "https://example.test/health?token=secret").to_return(status: 200)
+
+    result = UptimeProbe.check("https://example.test/health?token=secret")
+
+    assert_equal 200, result[:status]
+    assert_requested :get, "https://example.test/health?token=secret"
+  end
+
   test "uses UPTIME_PROBE_URL when set" do
     ENV["UPTIME_PROBE_URL"] = "https://probe.test/"
     stub_request(:get, "https://probe.test/").to_return(status: 200)

--- a/test/services/uptime_schedule_test.rb
+++ b/test/services/uptime_schedule_test.rb
@@ -3,11 +3,14 @@ require "test_helper"
 class UptimeScheduleTest < ActiveSupport::TestCase
   setup do
     @original = ENV["UPTIME_PROBE_URL"]
+    @original_token = ENV["UPTIME_PROBE_TOKEN"]
     ENV["UPTIME_PROBE_URL"] = "https://probe.test"
+    ENV.delete("UPTIME_PROBE_TOKEN")
   end
 
   teardown do
     @original ? ENV["UPTIME_PROBE_URL"] = @original : ENV.delete("UPTIME_PROBE_URL")
+    @original_token ? ENV["UPTIME_PROBE_TOKEN"] = @original_token : ENV.delete("UPTIME_PROBE_TOKEN")
   end
 
   # 2026-06-10 is a Wednesday; times below are ET (the app time zone).
@@ -23,6 +26,12 @@ class UptimeScheduleTest < ActiveSupport::TestCase
     assert_equal %w[menu admin], UptimeSchedule.targets.map(&:name)
     assert_equal "https://probe.test/menu.json", UptimeSchedule.targets.first.url
     assert_equal "https://probe.test/admin", UptimeSchedule.targets.last.url
+  end
+
+  test "admin target uses the token-guarded health endpoint when a token is configured" do
+    ENV["UPTIME_PROBE_TOKEN"] = "probe secret"
+
+    assert_equal "https://probe.test/health/admin?token=probe+secret", UptimeSchedule.targets.last.url
   end
 
   test "targets is empty when no probe url is configured" do

--- a/test/services/uptime_schedule_test.rb
+++ b/test/services/uptime_schedule_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class UptimeScheduleTest < ActiveSupport::TestCase
+  setup do
+    @original = ENV["UPTIME_PROBE_URL"]
+    ENV["UPTIME_PROBE_URL"] = "https://probe.test"
+  end
+
+  teardown do
+    @original ? ENV["UPTIME_PROBE_URL"] = @original : ENV.delete("UPTIME_PROBE_URL")
+  end
+
+  # 2026-06-10 is a Wednesday; times below are ET (the app time zone).
+  WED = "2026-06-10".freeze
+  THU = "2026-06-11".freeze
+  MON = "2026-06-08".freeze
+
+  def et(date, hms)
+    Time.zone.parse("#{date} #{hms}")
+  end
+
+  test "targets build menu and admin URLs from the probe base" do
+    assert_equal %w[menu admin], UptimeSchedule.targets.map(&:name)
+    assert_equal "https://probe.test/menu.json", UptimeSchedule.targets.first.url
+    assert_equal "https://probe.test/admin", UptimeSchedule.targets.last.url
+  end
+
+  test "targets is empty when no probe url is configured" do
+    ENV.delete("UPTIME_PROBE_URL")
+    assert_empty UptimeSchedule.targets
+    assert_empty UptimeSchedule.due_targets(et(WED, "18:00"))
+  end
+
+  test "menu is due every 5 minutes during the Wednesday evening surge" do
+    assert UptimeSchedule.due?("menu", et(WED, "18:05"))
+    assert UptimeSchedule.due?("menu", et(WED, "21:55"))
+  end
+
+  test "menu is due every 15 minutes during waking hours" do
+    assert UptimeSchedule.due?("menu", et(THU, "10:15"))
+    assert_not UptimeSchedule.due?("menu", et(THU, "10:05"))
+  end
+
+  test "menu is due hourly overnight" do
+    assert UptimeSchedule.due?("menu", et(THU, "03:00"))
+    assert_not UptimeSchedule.due?("menu", et(THU, "03:15"))
+    assert UptimeSchedule.due?("menu", et(THU, "23:00"))
+  end
+
+  test "admin is due every 15 minutes during Wednesday menu posting" do
+    assert UptimeSchedule.due?("admin", et(WED, "18:15"))
+    assert_not UptimeSchedule.due?("admin", et(WED, "18:05"))
+  end
+
+  test "admin is due during Russell's Thu-Sat bakery hours" do
+    assert UptimeSchedule.due?("admin", et(THU, "10:15"))
+    assert UptimeSchedule.due?("admin", et("2026-06-13", "07:00")) # Saturday
+  end
+
+  test "admin is not probed outside Russell's windows" do
+    assert_not UptimeSchedule.due?("admin", et(MON, "10:15"))
+    assert_not UptimeSchedule.due?("admin", et(THU, "20:00"))
+    assert_not UptimeSchedule.due?("admin", et(THU, "03:00"))
+  end
+
+  test "times round to the nearest 5-minute slot so queue latency cannot skip a cadence boundary" do
+    assert UptimeSchedule.due?("menu", et(THU, "10:14:40"))
+    assert UptimeSchedule.due?("menu", et(THU, "10:15:55"))
+    assert_not UptimeSchedule.due?("menu", et(THU, "10:08:00"))
+  end
+
+  test "due_targets returns both targets when both cadences align" do
+    assert_equal %w[menu admin], UptimeSchedule.due_targets(et(WED, "18:00")).map(&:name)
+    assert_equal %w[menu], UptimeSchedule.due_targets(et(WED, "18:05")).map(&:name)
+  end
+
+  test "expected_checks counts due slots in a range" do
+    # Wed 6:00pm–6:55pm: menu every 5 min = 12 slots; admin every 15 = 4 slots
+    range = et(WED, "18:00")..et(WED, "18:55")
+    assert_equal 12, UptimeSchedule.expected_checks("menu", range)
+    assert_equal 4, UptimeSchedule.expected_checks("admin", range)
+  end
+end


### PR DESCRIPTION
Expands the one-shot uptime probe from #337 into recurring, recorded uptime monitoring — weighted toward the periods the site is actually used, surfaced in the activity feed, the weekly trends chart, the nightly anomaly prompt, and a new admin index. Also addresses the Codex review comment on #337.

## Schedule comes from real usage (180 days of Ahoy visits + orders, prod)

- **Wednesday evening is the event of the week**: the menu email lands ~6pm — 325 visits and 80 orders in that hour alone; Wednesday carries ~30% of all orders.
- **General traffic** runs ~7am–11pm ET; overnight is near-dead.
- **Russell's admin usage** clusters Thu–Sat daytime (Sat 7–8am, Thu/Fri late morning, Fri 5–6pm) plus Wednesday evening menu posting.

So `UptimeCheckJob` enqueues every 5 minutes and `UptimeSchedule` decides what's due (all times ET, slot-rounded so queue latency can't skip a boundary):

| Target | When | Cadence |
|--------|------|---------|
| `menu` (`/menu.json` — exercises Rails + Postgres + serialization, anonymous) | Wed 5–10pm | 5 min |
| | daily 7am–11pm | 15 min |
| | overnight | hourly |
| `admin` (`/admin` — 302 to sign-in proves the stack without stored credentials) | Wed 4–10pm, Thu–Sat 6am–7pm | 15 min |
| | otherwise | not probed |

≈ 250 checks/week, fine-grained where it counts.

## Detect & track without overreacting

- A single failed check is **data, not an incident** — no retries, no report.
- The **second consecutive failure** reports once to error tracking (`UptimeCheck::OutageError`, handled/warning) → `/admin/error_events` + weekly feed. No re-report until recovery.
- **Missed slots are the inverse signal**: if the whole app is down, the worker can't record failures. The feed compares actual checks to expected slots and reports the gap; the anomaly prompt explains how to read it (deploys explain a couple, long gaps mean real downtime).
- Checks trim at 90 days with the rest of the analytics.

## Surfacing

- `== Uptime (scheduled probes) ==` section in the activity feed text (feeds the nightly anomaly analysis): per-target % up, latency, each failure, missed slots.
- **Daily grid** gains an Uptime column (green/red, links to filtered raw checks).
- **Weekly trends chart** gains an `Uptime %` dataset on a 90–100 axis (a dip to 99% must be visible; on a 0–100 axis it wouldn't be).
- **`/admin/uptime_checks`**: read-only index with target/up/status/date filters and a failures scope.
- `UptimeCheckJob` is deliberately *not* in `RECURRING_JOB_LABELS` (it would drown the jobs summary at ~100 runs/day; missed-slot reporting covers its absence) — the schedule test now allows explicit exemptions.

## PR #337 review feedback

Codex P2: `UptimeProbe` built requests from `uri.path`, silently dropping the query string of a configured `UPTIME_PROBE_URL` (e.g. `/health?token=...`). Now requests `uri.request_uri` verbatim, with a regression test.

## Admin health endpoint (added in review)

The original `/admin` probe only proved a 302 — it fired before any DB query. The admin target now hits a token-guarded, probe-only `GET /health/admin?token=…` (`HealthController`) that runs the admin's real reads server-side: current menu loads, orders readable, `error_events` readable, and ready-job queue not stale (>15 min). A failure returns 503 naming the failing subcheck; a bad or missing token returns 404 so the route is invisible to scanners. No stored credentials or auth-bypass route. Falls back to `/admin` when `UPTIME_PROBE_TOKEN` is unset, so monitoring degrades instead of disappearing.

**Deploy step (optional but recommended):**
```
heroku config:set UPTIME_PROBE_TOKEN=$(ruby -rsecurerandom -e 'puts SecureRandom.hex(32)') --app motzibread
```

## Notes

- Works in prod with no new config (admin probe falls back to `/admin`); set `UPTIME_PROBE_TOKEN` to enable the deeper health checks. The job no-ops in dev/test.
- The nightly report's live probe stays — it answers "is the site up *right now*", the new section answers "was it up all week".
- Design spec with the full data pull: `docs/superpowers/specs/2026-06-11-uptime-monitoring.md`.

## Tests

38 new Minitest cases (schedule windows/slot rounding/expected-slot math, record!/outage dedup per target, job due-target probing, feed section + grid events + silent-target reporting, health endpoint subchecks/token guard, probe query string, trim, admin pages). Full suite: 479 Rails + 53 JS, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Screenshots

### admin/activity_feed
![admin/activity_feed](https://motzi.s3.us-east-1.amazonaws.com/public/gh/pr-344/1f9fnsdx/admin-activity_feed.png)

### admin/uptime_checks
![admin/uptime_checks](https://motzi.s3.us-east-1.amazonaws.com/public/gh/pr-344/1f9fnsdx/admin-uptime_checks.png)


