### PR TITLE
Clear RailsSettings cache before each test, not only after

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,12 @@ class ActiveSupport::TestCase
   setup do
     @original_github_token = ENV["GITHUB_TOKEN"]
     ENV["GITHUB_TOKEN"] = nil
+
+    # RailsSettings caches values (e.g. menu_id) in memory, surviving the
+    # transactional fixture rollback. Clearing only in teardown still let the
+    # first test in a worker read a polluted cache, so clear before each test
+    # too (#342).
+    Setting.clear_cache
   end
 
   teardown do


### PR DESCRIPTION
## Summary
- `Setting` (RailsSettings) caches values like `menu_id` in memory; transactional fixture rollback undoes the DB row but not the cache. With clearing only in `teardown`, the first test in a parallel worker (or an ordering edge) could read a polluted cache, making `Menu.current` resolve a stale id and raise `RecordNotFound` in certain shardings.
- Fix is the one suggested in the issue: also `Setting.clear_cache` in the global `setup` block, so every test starts with a cold settings cache. The `teardown` clear stays as belt-and-braces for anything reading settings between tests.

Closes #342

## Test plan
- [x] Six consecutive full parallel suite runs (441 tests each): no `RecordNotFound` flakes
- [x] One of the six runs hit an unrelated flake (`PG::TRDeadlockDetected` via DRb, 50 errors, not reproduced) — different failure mode from this issue; tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)